### PR TITLE
Fix html report to report >900

### DIFF
--- a/src/reportoutput.h
+++ b/src/reportoutput.h
@@ -967,10 +967,6 @@ var errors = {
 
 function error_overview() {
 
-  if ( (report.CityObjects == null) && (report.Primitives == null) ) {
-    // idx_error_table();
-    return;
-  }
   if (report.overview_errors == null) {
     var h = document.createElement("H3")           
     var t = document.createTextNode("No errors!");


### PR DESCRIPTION
A conditional prevented the generation of the
Overview of errors table when CityObjects and
Primitives were null in the json.

Fixes #109