### PR TITLE
Update tests for new pytest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,7 +128,7 @@ def citymodel():
 #-------------------------------------------------------- validation functions
 @pytest.fixture(scope="session")
 def validate(val3dity):
-    def _validate(file_path, options=solid(), val3dity=val3dity):
+    def _validate(file_path, options=solid, val3dity=val3dity):
         """Validate a file
 
         :return: The error numbers. Empty list if the file is valid.
@@ -141,7 +141,7 @@ def validate(val3dity):
             assert isinstance(file_path, list)
         except Exception:
             return(["Something went really wrong. Validate the file separately with val3dity."])
-        assert isinstance(options, list)
+        # assert isinstance(options, list)
 
         command = [val3dity] + options + file_path
         

--- a/tests/test_geometry_generic.py
+++ b/tests/test_geometry_generic.py
@@ -315,103 +315,103 @@ def data_405(request, dir_geometry_generic):
     return(file_path)
 
 #----------------------------------------------------------------------- Tests
-def test_101(validate, data_101):
-    error = validate(data_101)
+def test_101(validate, data_101, solid):
+    error = validate(data_101, options=solid)
     assert(error == [101])
 
-def test_102(validate, data_102):
-    error = validate(data_102)
+def test_102(validate, data_102, solid):
+    error = validate(data_102, options=solid)
     assert(error == [102])
 
-def test_104(validate, data_104):
-    error = validate(data_104)
+def test_104(validate, data_104, solid):
+    error = validate(data_104, options=solid)
     assert(error == [104])
 
-def test_201(validate, data_201):
-    error = validate(data_201)
+def test_201(validate, data_201, solid):
+    error = validate(data_201, options=solid)
     assert(error == [201])
 
-def test_202(validate, data_202):
-    error = validate(data_202)
+def test_202(validate, data_202, solid):
+    error = validate(data_202, options=solid)
     assert(error == [202])
 
-def test_203(validate, data_203):
-    error = validate(data_203)
+def test_203(validate, data_203, solid):
+    error = validate(data_203, options=solid)
     assert(error == [203])
 
-def test_204(validate, data_204):
-    error = validate(data_204)
+def test_204(validate, data_204, solid):
+    error = validate(data_204, options=solid)
     assert(error == [204])
 
-def test_204_valid(validate, data_204_valid):
-    error = validate(data_204_valid)
+def test_204_valid(validate, data_204_valid, solid):
+    error = validate(data_204_valid, options=solid)
     assert(error == [])
 
-def test_205(validate, data_205):
-    error = validate(data_205)
+def test_205(validate, data_205, solid):
+    error = validate(data_205, options=solid)
     assert(error == [205])
 
-def test_206(validate, data_206):
-    error = validate(data_206)
+def test_206(validate, data_206, solid):
+    error = validate(data_206, options=solid)
     assert(error == [206])
 
-def test_207(validate, data_207):
-    error = validate(data_207)
+def test_207(validate, data_207, solid):
+    error = validate(data_207, options=solid)
     assert(error == [207])
 
-def test_208(validate, data_208):
-    error = validate(data_208)
+def test_208(validate, data_208, solid):
+    error = validate(data_208, options=solid)
     assert(error == [208])
 
-def test_301(validate, data_301):
-    error = validate(data_301)
+def test_301(validate, data_301, solid):
+    error = validate(data_301, options=solid)
     assert(error == [301])
 
-def test_302(validate, data_302):
-    error = validate(data_302)
+def test_302(validate, data_302, solid):
+    error = validate(data_302, options=solid)
     assert(error == [302])
 
-def test_303(validate, data_303):
-    error = validate(data_303)
+def test_303(validate, data_303, solid):
+    error = validate(data_303, options=solid)
     assert(error == [303])
 
 def test_303_cs(validate, data_303_cs, compositesurface):
     error = validate(data_303_cs, options=compositesurface)
     assert(error == [303])
 
-def test_305(validate, data_305):
-    error = validate(data_305)
+def test_305(validate, data_305, solid):
+    error = validate(data_305, options=solid)
     assert(error == [305])
 
-def test_306(validate, data_306):
-    error = validate(data_306)
+def test_306(validate, data_306, solid):
+    error = validate(data_306, options=solid)
     assert(error == [306])
 
-def test_307(validate, data_307):
+def test_307(validate, data_307, solid):
     """See #62"""
-    error = validate(data_307)
+    error = validate(data_307, options=solid)
     assert(error == [303, 307])
 
-def test_307_1(validate, data_307_1):
-    error = validate(data_307_1)
+def test_307_1(validate, data_307_1, solid):
+    error = validate(data_307_1, options=solid)
     assert(error == [307])
 
-def test_401(validate, data_401):
-    error = validate(data_401)
+def test_401(validate, data_401, solid):
+    error = validate(data_401, options=solid)
     assert(error == [401])
 
-def test_402_inner(validate, data_402_1):
-    error = validate(data_402_1)
+def test_402_inner(validate, data_402_1, solid):
+    error = validate(data_402_1, options=solid)
     assert(error == [402])
 
-def test_403(validate, data_403):
-    error = validate(data_403)
+def test_403(validate, data_403, solid):
+    error = validate(data_403, options=solid)
     assert(error == [403])
 
-def test_404(validate, data_404):
-    error = validate(data_404)
+def test_404(validate, data_404, solid):
+    error = validate(data_404, options=solid)
     assert(error == [404])
 
-def test_405(validate, data_405):
-    error = validate(data_405)
+def test_405(validate, data_405, solid):
+    error = validate(data_405, options=solid)
     assert(error == [405])

--- a/tests/test_geometry_specific.py
+++ b/tests/test_geometry_specific.py
@@ -114,7 +114,7 @@ def test_503(validate, data_503, citymodel):
     assert(error == [503])
 
 def test_601(validate, data_601, citymodel):
-    error = validate(data_601)
+    error = validate(data_601, options=citymodel)
     assert(error == [601])
 
 def test_601_overlap(validate, data_601_overlap, options_overlap):

--- a/tests/test_valid.py
+++ b/tests/test_valid.py
@@ -118,44 +118,44 @@ def data_inner_shell(request, dir_valid, data_basecube):
 
 #----------------------------------------------------------------------- Tests
 
-def test_large_coords(validate, data_large_coords):
-    error = validate(data_large_coords)
+def test_large_coords(validate, data_large_coords, solid):
+    error = validate(data_large_coords, options=solid)
     assert(error == [])
 
-def test_v_405(validate, data_v_405):
-    error = validate(data_v_405)
+def test_v_405(validate, data_v_405, solid):
+    error = validate(data_v_405, options=solid)
     assert(error == [])
 
-def test_v_104(validate, data_planar):
-    error = validate(data_planar)
+def test_v_104(validate, data_planar, solid):
+    error = validate(data_planar, options=solid)
     assert(error == [301])
 
-def test_planar(validate, data_planar):
-    error = validate(data_planar)
+def test_planar(validate, data_planar, solid):
+    error = validate(data_planar, options=solid)
     assert(error == [301])
 
-def test_nearly_collinear(validate, data_nearly_collinear):
-    error = validate(data_nearly_collinear)
+def test_nearly_collinear(validate, data_nearly_collinear, solid):
+    error = validate(data_nearly_collinear, options=solid)
     assert(error == [])
 
-def test_self_fold(validate, data_self_fold):
-    error = validate(data_self_fold)
+def test_self_fold(validate, data_self_fold, solid):
+    error = validate(data_self_fold, options=solid)
     assert(error == [])
 
-def test_closed_top(validate, data_closed_top):
-    error = validate(data_closed_top)
+def test_closed_top(validate, data_closed_top, solid):
+    error = validate(data_closed_top, options=solid)
     assert(error == [])
 
 @pytest.mark.full
-def test_inner_shell(validate, data_inner_shell):
-    error = validate(data_inner_shell)
+def test_inner_shell(validate, data_inner_shell, solid):
+    error = validate(data_inner_shell, options=solid)
     assert(error == [])
 
-def test_multi_solid(validate, data_multi_solid):
-    error = validate(data_multi_solid)
+def test_multi_solid(validate, data_multi_solid, solid):
+    error = validate(data_multi_solid, options=solid)
     assert(error == [])
 
 # data_composite_solid is in conftest.py
-def test_composite_solid(validate, data_composite_solid):
-    error = validate(data_composite_solid)
+def test_composite_solid(validate, data_composite_solid, solid):
+    error = validate(data_composite_solid, options=solid)
     assert(error == [])


### PR DESCRIPTION
Fixes #139
From now on, always need to pass sth to the options parameter in
validate(). For example validate(data, options=solid). See the tests for details.