### PR TITLE
Implement docker way of usage for this project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ if ( COMMAND cmake_policy )
   cmake_policy( SET CMP0003 NEW )  
 endif()
 
+if (MSVC)
+    add_definitions("/EHsc")
+endif(MSVC)
+
 # CGAL
 find_package( CGAL QUIET COMPONENTS core )
 if ( CGAL_FOUND )
@@ -57,6 +61,6 @@ add_executable(val3dity ${SRC_FILES})
 
 # add_to_cached_list( CGAL_EXECUTABLE_TARGETS val3dity )
 
-target_link_libraries(val3dity ${CGAL_LIBRARIES} ${CGAL_3RD_PARTY_LIBRARIES} ${GEOS_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} thirdparty)
+target_link_libraries(val3dity ${CGAL_LIBRARIES} ${CGAL_3RD_PARTY_LIBRARIES} ${GEOS_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} thirdparty)
 
 install(TARGETS val3dity DESTINATION bin)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,118 @@
+FROM alpine:3.9
+
+ENV CXX="g++ -std=c++98"
+
+# Install geos
+RUN apk --update add --virtual .geos-deps \
+        which \
+        make \
+        gcc \
+        g++ \
+        file \
+        git \
+        autoconf \
+        automake \
+        libtool && \
+    cd /tmp && \
+    git clone https://git.osgeo.org/gitea/geos/geos.git geos && \
+    cd geos && \
+    git checkout 3.7.1 && \
+    ./autogen.sh && \
+    ./configure && \
+    make && \
+    make check && \
+    make install && \
+    cd / && \
+    apk del .geos-deps && \
+    rm -rf /tmp/* && \
+    rm -rf /user/local/man
+
+# install CGAL
+RUN apk --update add --virtual .cgal-deps \
+        which \
+        make \
+        cmake \
+        gcc \
+        g++ \
+        eigen-dev \
+        boost-dev \
+        gmp-dev \
+        mpfr-dev \
+        zlib-dev && \
+    cd /tmp && \
+    wget https://github.com/CGAL/cgal/releases/download/releases%2FCGAL-4.13.1/CGAL-4.13.1.tar.xz && \
+    tar xf CGAL-4.13.1.tar.xz && \
+    rm -f CGAL-4.13.1.tar.xz && \
+    cd CGAL-4.13.1 && \
+    mkdir build && \
+    cd build && \
+    cmake -DCMAKE_BUILD_TYPE=Release -DWITH_Eigen3=ON .. && \
+    make && \
+    make install && \
+    cp lib/* /usr/local/lib && \
+    cd / && \
+    apk del .cgal-deps && \
+    rm -rf /tmp/* && \
+    rm -rf /user/local/man
+
+# install val3dity
+RUN apk --update add --virtual .val3dity-deps \
+        make \
+        cmake \
+        gcc \
+        g++ \
+        boost-dev \
+        eigen-dev \
+        gmp-dev \
+        mpfr-dev \
+        python3 \
+        pytest \
+        py-yaml \
+        py-lxml \
+        py3-setuptools && \
+    cd /tmp && \
+    wget https://github.com/tudelft3d/val3dity/archive/2.1.1.tar.gz && \
+    tar xzf 2.1.1.tar.gz && \
+    rm -f 2.1.1.tar.gz && \
+    cd val3dity-2.1.1 && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make && \
+    make install && \
+    cd .. &&\
+    ls -ls . && \
+    val3dity data/cityjson/cube.json && \
+    python3 -m pytest --runfull && \
+    apk del .val3dity-deps && \
+    cd / && \
+    apk --update add \
+        make \
+        gcc \
+        g++ \
+        boost \
+        eigen \
+        gmp \
+        bash \
+        mpfr3 && \
+    rm -rf /tmp/* && \
+    rm -rf /user/local/man
+
+RUN mkdir /data && \
+    chown 1001 /data && \
+    chgrp 0 /data && \
+    chmod g=u /data && \
+    chgrp 0 /etc/passwd && \
+    chmod g=u /etc/passwd
+    
+RUN val3dity --version
+
+USER 1001
+
+COPY --chown=1001:0 uid_entrypoint.sh /usr/local/bin/
+
+WORKDIR /data
+
+ENTRYPOINT ["/usr/local/bin/uid_entrypoint.sh"]
+
+CMD ["--version"]

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ Finally, to see all the options possible:
 
 If you are eager to contribute but do not want to fiddle with setting up the required libraries, Vagrant can take care of that. It creates a development environment in a virtual machine, which you can use to compile and run val3dity. For details see VAGRANT.md
 
+## Usage of Docker
+
+To run val3dity over Docker simply execute:
+
+    $ docker run --rm  -v <local path where your files are>:/data tudelft3d/val3dity:2.1.1 <name of the dedicated file>
+
 ## Web application
 
 If you don't want to go through the troubles of compiling and/or installing val3dity, we suggest you use the [web application](http://geovalidation.bk.tudelft.nl/val3dity).

--- a/uid_entrypoint.sh
+++ b/uid_entrypoint.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Create passwd entry for arbitrary user ID
+if [[ -z "$(awk -F ':' "\$3 == $(id -u)" /etc/passwd)" ]]; then
+    echo "Adding arbitrary user"
+    echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
+    echo "$(awk -F ':' "\$3 == $(id -u)" /etc/passwd)"
+fi
+
+echo "Running as $(id -un):$(id -gn)"
+
+if [[ $@ == /bin* ]]
+then
+    exec "$@"
+else
+    val3dity $@
+fi


### PR DESCRIPTION
To be able to use this Docker approach in its full convenience I suggest someone of tudelft3d team opens an account on hub.docker.com and publishes this image.

This can be done by executing from project root:

    $ docker build . -t tudelft3d/val3dity:2.1.1

Before publishing you need to be logged in at docker hub:

    $ docker login

And after this to publish it on Docker Hub:

    $ docker push tudelft3d/val3dity:2.1.1

For the future maintenance this means to adjust the Dockerfile as well (versions and build, like in vagrant approach). This can be easily done by using travis for build automation. This integrates really well with github and is free for open source projects. If you are interested in this: Let me know.