### PR TITLE
Change input containers so that they work with CGAL's polygon soup

### DIFF
--- a/src/val3dity.cpp
+++ b/src/val3dity.cpp
@@ -178,7 +178,7 @@ validate(json& j,
 }
 
 bool 
-is_valid(const std::vector<std::vector<double>>& vertices,
+is_valid(const std::vector<std::array<double, 3>>& vertices,
          const std::vector<std::vector<int>>& faces,
          double tol_snap, 
          double planarity_d2p_tol, 
@@ -190,7 +190,7 @@ is_valid(const std::vector<std::vector<double>>& vertices,
 }
 
 json
-validate(const std::vector<std::vector<double>>& vertices,
+validate(const std::vector<std::array<double, 3>>& vertices,
          const std::vector<std::vector<int>>& faces,
          double tol_snap, 
          double planarity_d2p_tol, 

--- a/src/val3dity.h
+++ b/src/val3dity.h
@@ -66,7 +66,7 @@ validate(std::string& input,
          double overlap_tol=-1.0);
 
 json 
-validate(const std::vector<std::vector<double>>& vertices,
+validate(const std::vector<std::array<double, 3>>& vertices,
          const std::vector<std::vector<int>>& triangle_ids,
          double tol_snap=0.001, 
          double planarity_d2p_tol=0.01, 
@@ -74,7 +74,7 @@ validate(const std::vector<std::vector<double>>& vertices,
          double overlap_tol=-1.0);
 
 bool 
-is_valid(const std::vector<std::vector<double>>& vertices,
+is_valid(const std::vector<std::array<double, 3>>& vertices,
          const std::vector<std::vector<int>>& triangle_ids,
          double tol_snap=0.001, 
          double planarity_d2p_tol=0.01, 


### PR DESCRIPTION
std::vector<double> is not supported point type, but std::array<double, 3> is.