### PR TITLE
Add val3dity ostream

### DIFF
--- a/src/CityObject.cpp
+++ b/src/CityObject.cpp
@@ -31,6 +31,7 @@
 #include "definitions.h"
 #include "input.h"
 #include "validate_prim_toporel.h"
+#include "val3dity_ostream.h"
 
 namespace val3dity
 {
@@ -65,7 +66,7 @@ bool CityObject::validate_building(double tol_overlap)
   bool bValid = true;
   if (_lsPrimitives.size() == 0)
     return bValid;
-  std::clog << "--- Interactions between BuildingParts ---" << std::endl;
+  *val3dityclog << "--- Interactions between BuildingParts ---" << std::endl;
   std::vector<Error> lsErrors;
   //-- process each LoDs separately
   std::set<std::string> uniquelods;
@@ -79,14 +80,14 @@ bool CityObject::validate_building(double tol_overlap)
         g1lod.push_back(p);
       }
     }
-    // std::cout << g1lod.size() << std::endl;
+    // *val3ditycout << g1lod.size() << std::endl;
     if (g1lod.size() > 1) {
-      std::clog << "LoD" << lod << " has " << g1lod.size() 
+      *val3dityclog << "LoD" << lod << " has " << g1lod.size()
         << " geometries, validating for overlaps." << std::endl;
       if (do_primitives_interior_overlap(g1lod, 601, lsErrors, tol_overlap) == true)
       {
         bValid = false;
-        std::clog << "Error: overlapping building parts (LoD" << lod << ")" << std::endl;
+        *val3dityclog << "Error: overlapping building parts (LoD" << lod << ")" << std::endl;
         for (auto& e : lsErrors) {
           std::stringstream msg;
           msg << "Geometries for LoD" << lod;

--- a/src/CompositeSolid.cpp
+++ b/src/CompositeSolid.cpp
@@ -29,6 +29,7 @@
 #include "CompositeSolid.h"
 #include "input.h"
 #include "geomtools.h"
+#include "val3dity_ostream.h"
 
 namespace val3dity
 {
@@ -105,7 +106,7 @@ bool CompositeSolid::validate(double tol_planarity_d2p, double tol_planarity_nor
     for (int i = 0; i < _lsSolids.size(); i++)
       lsNefs.push_back(_lsSolids[i]->get_nef_polyhedron());
 //-- 1. check if any 2 are the same? ERROR:502
-    std::clog << "-----Are two solids duplicated" << std::endl;
+    *val3dityclog << "-----Are two solids duplicated" << std::endl;
     for (int i = 0; i < (lsNefs.size() - 1); i++)
     {
       for (int j = i + 1; j < lsNefs.size(); j++) 
@@ -122,7 +123,7 @@ bool CompositeSolid::validate(double tol_planarity_d2p, double tol_planarity_nor
     if (isValid == true)
     {
 //-- 2. check if their interior intersects ERROR:501
-      std::clog << "-----Intersections of solids" << std::endl;
+      *val3dityclog << "-----Intersections of solids" << std::endl;
       std::vector<Nef_polyhedron*> lsNefsEroded;
       if (tol_overlap > 0.0)
       {
@@ -158,7 +159,7 @@ bool CompositeSolid::validate(double tol_planarity_d2p, double tol_planarity_nor
     if (isValid == true)
     {
 //-- 3. check if their union yields one solid ERROR:503
-      std::clog << "-----Forming one solid (union)" << std::endl;
+      *val3dityclog << "-----Forming one solid (union)" << std::endl;
       std::vector<Nef_polyhedron*> lsNefsDilated;
       if (tol_overlap > 0.0)
       {

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -28,13 +28,10 @@
 
 #include "Feature.h"
 #include "input.h"
-#include <iostream>
+#include "val3dity_ostream.h"
 
 namespace val3dity
 {
-
-
-
 
 std::string Feature::get_id()
 {
@@ -99,40 +96,40 @@ const std::vector<Primitive*>& Feature::get_primitives()
 
 bool Feature::validate_generic(double tol_planarity_d2p, double tol_planarity_normals, double tol_overlap)
 {
-  std::clog << std::endl << "######### Validating Feature #########" << std::endl;
-  std::clog << "id:   " << this->get_id() << std::endl;
-  std::clog << "type: " << this->get_type() << std::endl;
-  std::clog << "--" << std::endl;
+  *val3dityclog << std::endl << "######### Validating Feature #########" << std::endl;
+  *val3dityclog << "id:   " << this->get_id() << std::endl;
+  *val3dityclog << "type: " << this->get_type() << std::endl;
+  *val3dityclog << "--" << std::endl;
   bool bValid = true;
   if (this->is_empty() == true) {
     this->add_error(906, "Feature has no geometry defined (or val3dity doesn't handle this type).", "");
     bValid = false;
   }
   if (_lsPrimitives.size() > 500) {
-    std::cout << "Validating " << _lsPrimitives.size() << " geometric primitives, this could be slow." << std::endl << std::flush;
+    *val3ditycout << "Validating " << _lsPrimitives.size() << " geometric primitives, this could be slow." << std::endl << std::flush;
   }
   for (auto& p : _lsPrimitives)
   {
-    std::clog << "======== Validating Primitive ========" << std::endl;
+    *val3dityclog << "======== Validating Primitive ========" << std::endl;
     switch(p->get_type())
     {
-      case 0: std::clog << "Solid"             << std::endl; break;
-      case 1: std::clog << "CompositeSolid"    << std::endl; break;
-      case 2: std::clog << "MultiSolid"        << std::endl; break;
-      case 3: std::clog << "CompositeSurface"  << std::endl; break;
-      case 4: std::clog << "MultiSurface"      << std::endl; break;
-      case 5: std::clog << "GeometryTemplate"  << std::endl; break;
-      case 9: std::clog << "ALL"               << std::endl; break;
+      case 0: *val3dityclog << "Solid"             << std::endl; break;
+      case 1: *val3dityclog << "CompositeSolid"    << std::endl; break;
+      case 2: *val3dityclog << "MultiSolid"        << std::endl; break;
+      case 3: *val3dityclog << "CompositeSurface"  << std::endl; break;
+      case 4: *val3dityclog << "MultiSurface"      << std::endl; break;
+      case 5: *val3dityclog << "GeometryTemplate"  << std::endl; break;
+      case 9: *val3dityclog << "ALL"               << std::endl; break;
     }
-    std::clog << "id: " << p->get_id() << std::endl;
-    std::clog << "--" << std::endl;
+    *val3dityclog << "id: " << p->get_id() << std::endl;
+    *val3dityclog << "--" << std::endl;
     if (p->validate(tol_planarity_d2p, tol_planarity_normals, tol_overlap) == false)
     {
-      std::clog << "======== INVALID ========" << std::endl;
+      *val3dityclog << "======== INVALID ========" << std::endl;
       bValid = false;
     }
     else
-      std::clog << "========= VALID =========" << std::endl;
+      *val3dityclog << "========= VALID =========" << std::endl;
   }
   _is_valid = bValid;
   return bValid;
@@ -144,12 +141,12 @@ void Feature::add_error(int code, std::string whichgeoms, std::string info)
   _is_valid = 0;
   std::tuple<std::string, std::string> a(whichgeoms, info);
   _errors[code].push_back(a);
-  std::clog << "\tERROR " << code << ": " << ALL_ERRORS[code];
+  *val3dityclog << "\tERROR " << code << ": " << ALL_ERRORS[code];
   if (whichgeoms.empty() == false)
-    std::clog << " (id: " << whichgeoms << ")";
-  std::clog << std::endl;
+    *val3dityclog << " (id: " << whichgeoms << ")";
+  *val3dityclog << std::endl;
   if (info.empty() == false)
-    std::clog << "\t[" << info << "]" << std::endl;
+    *val3dityclog << "\t[" << info << "]" << std::endl;
 }
 
 std::set<int> Feature::get_unique_error_codes()

--- a/src/IndoorGraph.cpp
+++ b/src/IndoorGraph.cpp
@@ -30,6 +30,7 @@
 #include "IndoorGraph.h"
 #include "definitions.h"
 #include "input.h"
+#include "val3dity_ostream.h"
 
 namespace val3dity
 {
@@ -50,7 +51,7 @@ IndoorGraph::~IndoorGraph()
 
 void IndoorGraph::add_vertex(std::string theid, double x, double y, double z, std::string dual, std::vector<std::string> vadj)
 {
-  // std::cout << "ADDING VERTEX" << std::endl;
+  // *val3ditycout << "ADDING VERTEX" << std::endl;
   Point3 v(x, y, z);
   _vertices[theid] = std::make_tuple(v, dual, vadj);
 }
@@ -58,7 +59,7 @@ void IndoorGraph::add_vertex(std::string theid, double x, double y, double z, st
 
 bool IndoorGraph::validate() 
 {
-  std::cout << "VALIDATE IndoorGraph" << std::endl;
+  *val3ditycout << "VALIDATE IndoorGraph" << std::endl;
   return true;
   // if (_is_valid != -1)
   //   return _is_valid;

--- a/src/IndoorModel.cpp
+++ b/src/IndoorModel.cpp
@@ -32,6 +32,7 @@
 #include "input.h"
 #include "Solid.h"
 #include "validate_prim_toporel.h"
+#include "val3dity_ostream.h"
 
 namespace val3dity
 {
@@ -58,7 +59,7 @@ bool IndoorModel::validate(double tol_planarity_d2p, double tol_planarity_normal
   // 5. adj in dual == adj in primal
   // 
 
-  std::clog << "--- Validation of IndoorModel ---" << std::endl;
+  *val3dityclog << "--- Validation of IndoorModel ---" << std::endl;
   if (_is_valid != -1)
     return _is_valid;
 
@@ -69,7 +70,7 @@ bool IndoorModel::validate(double tol_planarity_d2p, double tol_planarity_normal
 
 //-- 2. 701 - CELLS_OVERLAP
 //--    overlapping test
-  std::clog << "--- Overlapping tests between Cells ---" << std::endl;
+  *val3dityclog << "--- Overlapping tests between Cells ---" << std::endl;
   std::vector<std::tuple<std::string,Solid*>> lsCells;
   for (auto& el : _cells)
     lsCells.push_back(std::make_tuple(el.first, (Solid*)_lsPrimitives[std::get<0>(el.second)]));
@@ -77,22 +78,22 @@ bool IndoorModel::validate(double tol_planarity_d2p, double tol_planarity_normal
   if (are_cells_interior_disconnected_with_aabb(lsCells, 701, lsErrors, tol_overlap) == false)
   {
     bValid = false;
-    std::clog << "Error: Cells have overlapping interior" << std::endl;
+    *val3dityclog << "Error: Cells have overlapping interior" << std::endl;
     for (auto& e : lsErrors)
       this->add_error(e.errorcode, e.info1, e.info2);
   }
 
 //-- 3. 702 - DUAL_VERTEX_OUTSIDE_CELL
 //--    is dual vertex of each cell located inside its Cell?
-  std::clog << "======== Validating Dual Vertex (Point-in-Solid tests) ========" << std::endl;
+  *val3dityclog << "======== Validating Dual Vertex (Point-in-Solid tests) ========" << std::endl;
   for (auto& el : _cells)
   {
-    std::clog << "Cell (" << std::get<2>(el.second) << ") id=" << el.first;
+    *val3dityclog << "Cell (" << std::get<2>(el.second) << ") id=" << el.first;
     // TODO : what to do with many graphs here?
     //-- check if there's a dual, something there's not (and it's valid)
     if (std::get<1>(el.second) == "") 
     {
-      std::clog << " has no dual vertex" << std::endl;
+      *val3dityclog << " has no dual vertex" << std::endl;
     }
     else 
     {
@@ -110,7 +111,7 @@ bool IndoorModel::validate(double tol_planarity_d2p, double tol_planarity_normal
         // std::stringstream msg;
         // msg << "Cell (" << std::get<2>(el.second) << ") id=" << el.first << " dual doesn't exist";
         // this->add_error(704, msg.str(), "");
-        std::clog << " ==> dual does not exist" << std::endl;
+        *val3dityclog << " ==> dual does not exist" << std::endl;
       } 
       else 
       {
@@ -125,7 +126,7 @@ bool IndoorModel::validate(double tol_planarity_d2p, double tol_planarity_normal
           bValid = false;
         }
         else
-          std::clog << " --> ok" << std::endl;
+          *val3dityclog << " --> ok" << std::endl;
       }
     }
   }
@@ -133,7 +134,7 @@ bool IndoorModel::validate(double tol_planarity_d2p, double tol_planarity_normal
 //-- 4. 703 - PRIMAL_DUAL_XLINKS_ERROR
 //--    are primal-dual graphs valid
 //--    this validates the XLinks basically, which is not done by XSD
-  std::clog << "======== Validating Primal-Dual links ========" << std::endl;
+  *val3dityclog << "======== Validating Primal-Dual links ========" << std::endl;
   for (auto& el : _cells)
   {
     std::string pdid = std::get<1>(el.second);
@@ -141,7 +142,7 @@ bool IndoorModel::validate(double tol_planarity_d2p, double tol_planarity_normal
     if (pdid == "") 
     {
       //-- this is allowed, a cell does not need to have a dual vertex
-      std::clog << "Cell id=" << el.first << " has no dual vertex" << std::endl;
+      *val3dityclog << "Cell id=" << el.first << " has no dual vertex" << std::endl;
       continue;
     }
     if (this->get_number_graphs() == 0) {
@@ -195,14 +196,14 @@ bool IndoorModel::validate(double tol_planarity_d2p, double tol_planarity_normal
 
 //-- 5. 704 - PRIMAL_DUAL_ADJACENCIES_INCONSISTENT  
 //--    if 2 cells are adjacent in the primal, are they also in the dual?
-  std::clog << "======== Validating Primal-Dual links ========" << std::endl;
+  *val3dityclog << "======== Validating Primal-Dual links ========" << std::endl;
   for (auto& el : _cells)
   {
     std::string pdid = std::get<1>(el.second);
     if (pdid == "")
     {
       //-- this is allowed, a cell does not need to have a dual vertex
-      std::clog << "Cell id=" << el.first << " has no dual vertex" << std::endl;
+      *val3dityclog << "Cell id=" << el.first << " has no dual vertex" << std::endl;
       continue;
     }
     if (this->get_number_graphs() == 0) {
@@ -217,20 +218,20 @@ bool IndoorModel::validate(double tol_planarity_d2p, double tol_planarity_normal
         std::string cadjid = std::get<1>(g->get_vertex(vadj));
         if (el.first > cadjid)
           continue;
-        std::clog << "Cells id=" << el.first << " id=" << cadjid;
+        *val3dityclog << "Cells id=" << el.first << " id=" << cadjid;
         int re = are_primitives_adjacent(_lsPrimitives[std::get<0>(el.second)],
                                          _lsPrimitives[std::get<0>(_cells[cadjid])],
                                          tol_overlap);
         if (re == 0) {
-          std::clog << " --> not valid" << std::endl;
+          *val3dityclog << " --> not valid" << std::endl;
           std::stringstream msg;
           bValid = false;
           msg << "Cells id=" << el.first << " & id=" << cadjid;
           this->add_error(704, msg.str(), "");
         } else if (re == -1) {
-          std::clog << " --> not valid, skipped adjacency test" << std::endl;
+          *val3dityclog << " --> not valid, skipped adjacency test" << std::endl;
         } else {
-          std::clog << " --> ok" << std::endl;
+          *val3dityclog << " --> ok" << std::endl;
         }
       }
     }

--- a/src/Primitive.cpp
+++ b/src/Primitive.cpp
@@ -28,7 +28,7 @@
 
 #include "Primitive.h"
 #include "input.h"
-#include <iostream>
+#include "val3dity_ostream.h"
 
 namespace val3dity
 {
@@ -76,12 +76,12 @@ void Primitive::add_error(int code, std::string whichgeoms, std::string info)
   _is_valid = 0;
   std::tuple<std::string, std::string> a(whichgeoms, info);
   _errors[code].push_back(a);
-  std::clog << "\tERROR " << code << ": " << ALL_ERRORS[code];
+  *val3dityclog << "\tERROR " << code << ": " << ALL_ERRORS[code];
   if (whichgeoms.empty() == false)
-    std::clog << " (id: " << whichgeoms << ")";
-  std::clog << std::endl;
+    *val3dityclog << " (id: " << whichgeoms << ")";
+  *val3dityclog << std::endl;
   if (info.empty() == false)
-    std::clog << "\t[" << info << "]" << std::endl;
+    *val3dityclog << "\t[" << info << "]" << std::endl;
 }
 
 std::set<int> Primitive::get_unique_error_codes()

--- a/src/Solid.cpp
+++ b/src/Solid.cpp
@@ -32,6 +32,7 @@
 
 #include "input.h"
 #include "validate_shell.h"
+#include "val3dity_ostream.h"
 
 namespace val3dity
 {
@@ -142,7 +143,7 @@ bool Solid::validate(double tol_planarity_d2p, double tol_planarity_normals, dou
       s += std::to_string(e);
       s += "; ";
     }
-    std::clog << "Errors: " << s << std::endl;
+    *val3dityclog << "Errors: " << s << std::endl;
     return false;
   }
   bool isValid = true;
@@ -309,7 +310,7 @@ bool Solid::validate_solid_with_nef()
 {
   bool isValid = true;
   //-- check orientation of the normals is outwards or inwards
-  std::clog << "-----Global orientation of normals" << std::endl;
+  *val3dityclog << "-----Global orientation of normals" << std::endl;
   int i = 0;
   for (auto& sh : this->get_shells())
   {
@@ -326,7 +327,7 @@ bool Solid::validate_solid_with_nef()
   if (this->num_ishells() == 0)
     return true;
     
-  std::clog << "---Inspection interactions between the " << (this->num_ishells() + 1) << " shells" << std::endl;
+  *val3dityclog << "---Inspection interactions between the " << (this->num_ishells() + 1) << " shells" << std::endl;
   std::vector<Nef_polyhedron> nefs;
   for (auto& sh : this->get_shells())
   {

--- a/src/Surface.cpp
+++ b/src/Surface.cpp
@@ -31,6 +31,7 @@
 #include "geomtools.h"
 #include "input.h"
 #include "validate_shell.h"
+#include "val3dity_ostream.h"
 #include <CGAL/Polygon_mesh_processing/self_intersections.h>
 #include <CGAL/Side_of_triangle_mesh.h>
 #include <geos_c.h>
@@ -85,12 +86,12 @@ void Surface::add_error(int code, std::string faceid, std::string info)
 {
   std::tuple<std::string, std::string> a(faceid, info);
   _errors[code].push_back(a);
-  std::clog << "\tERROR " << code << ": " << ALL_ERRORS[code];
+  *val3dityclog << "\tERROR " << code << ": " << ALL_ERRORS[code];
   if (faceid.empty() == false)
-    std::clog << " (face " << faceid << ")";
-  std::clog << std::endl;
+    *val3dityclog << " (face " << faceid << ")";
+  *val3dityclog << std::endl;
   if (info.empty() == false)
-    std::clog << "\t[" << info << "]" << std::endl;
+    *val3dityclog << "\t[" << info << "]" << std::endl;
 }
 
 std::set<int> Surface::get_unique_error_codes()
@@ -253,7 +254,7 @@ int Surface::number_faces()
 
 bool Surface::triangulate_shell()
 {
-  std::clog << "-----Triangulation of each surface" << std::endl;
+  *val3dityclog << "-----Triangulation of each surface" << std::endl;
   //-- read the facets
   size_t num = _lsFaces.size();
   for (int i = 0; i < static_cast<int>(num); i++)
@@ -388,7 +389,7 @@ void Surface::set_translation_min_values(double minx, double miny)
 
 bool Surface::validate_2d_primitives(double tol_planarity_d2p, double tol_planarity_normals)
 {
-  std::clog << "-----2D validation of each surface" << std::endl;
+  *val3dityclog << "-----2D validation of each surface" << std::endl;
   bool isValid = true;
   size_t num = _lsFaces.size();
   for (int i = 0; i < static_cast<int>(num); i++)
@@ -479,7 +480,7 @@ bool Surface::validate_2d_primitives(double tol_planarity_d2p, double tol_planar
     //-- triangulate faces of the shell
     triangulate_shell();
     //-- check planarity by normal deviation method (of all triangle)
-    std::clog << "-----Planarity of surfaces (with normals deviation)" << std::endl;
+    *val3dityclog << "-----Planarity of surfaces (with normals deviation)" << std::endl;
     std::vector< std::vector<int*> >::iterator it = _lsTr.begin();
     int j = 0;
     double deviation;
@@ -502,7 +503,7 @@ bool Surface::validate_2d_primitives(double tol_planarity_d2p, double tol_planar
 
 bool Surface::validate_as_multisurface(double tol_planarity_d2p, double tol_planarity_normals)
 {
-  std::clog << "--- MultiSurface validation ---" << std::endl;
+  *val3dityclog << "--- MultiSurface validation ---" << std::endl;
   if (_is_valid_2d == -1)
     return validate_2d_primitives(tol_planarity_d2p, tol_planarity_normals);
   else
@@ -523,14 +524,14 @@ bool Surface::is_shell(double tol_planarity_d2p, double tol_planarity_normals)
 
 bool Surface::validate_as_compositesurface(double tol_planarity_d2p, double tol_planarity_normals)
 {
-  std::clog << "--- CompositeSurface validation ---" << std::endl;
+  *val3dityclog << "--- CompositeSurface validation ---" << std::endl;
 //-- 1. Each surface should individually be valid
   if (_is_valid_2d == -1)
     validate_2d_primitives(tol_planarity_d2p, tol_planarity_normals);
   if (_is_valid_2d == 0)
     return false;
 //-- 2. Combinatorial consistency
-  std::clog << "--Combinatorial consistency" << std::endl;
+  *val3dityclog << "--Combinatorial consistency" << std::endl;
   _polyhedron = construct_CgalPolyhedron_incremental(&(_lsTr), &(_lsPts), this);
   if (this->has_errors() == true)
     return false;
@@ -561,7 +562,7 @@ bool Surface::validate_as_compositesurface(double tol_planarity_d2p, double tol_
   if (this->has_errors() == true)
     return false;
 //-- 2. Geometrical consistency (aka intersection tests between faces)
-  std::clog << "--Geometrical consistency" << std::endl;
+  *val3dityclog << "--Geometrical consistency" << std::endl;
   if (does_self_intersect() == false)
     return false;
   return true;
@@ -646,7 +647,7 @@ bool Surface::does_self_intersect()
 
 bool Surface::validate_as_shell(double tol_planarity_d2p, double tol_planarity_normals)
 {
-  std::clog << "--- Shell validation (#" << _id << ") ---" << std::endl;
+  *val3dityclog << "--- Shell validation (#" << _id << ") ---" << std::endl;
   if (_is_valid_2d == -1)
     validate_2d_primitives(tol_planarity_d2p, tol_planarity_normals);
   if (_is_valid_2d == 0)
@@ -658,7 +659,7 @@ bool Surface::validate_as_shell(double tol_planarity_d2p, double tol_planarity_n
     return false;
   }
 //-- 2. Combinatorial consistency
-  std::clog << "-----Combinatorial consistency" << std::endl;
+  *val3dityclog << "-----Combinatorial consistency" << std::endl;
   _polyhedron = construct_CgalPolyhedron_incremental(&(_lsTr), &(_lsPts), this);
   if (this->has_errors() == true)
     return false;
@@ -722,7 +723,7 @@ bool Surface::validate_as_shell(double tol_planarity_d2p, double tol_planarity_n
     return false;
   }
 //-- 3. Geometrical consistency (aka intersection tests between faces)
-  std::clog << "-----Geometrical consistency" << std::endl;
+  *val3dityclog << "-----Geometrical consistency" << std::endl;
   if (does_self_intersect() == false)
     return false;
   return true;

--- a/src/geomtools.cpp
+++ b/src/geomtools.cpp
@@ -199,10 +199,10 @@ Nef_polyhedron* erode_nef_polyhedron(Nef_polyhedron* nef, float r)
   Nef_polyhedron tmp = CGAL::minkowski_sum_3(complement, *se);
   *output = *nef - tmp;
   output->regularization();
-  // std::cout << "#volume " << output->number_of_volumes() << std::endl;
+  // *val3ditycout << "#volume " << output->number_of_volumes() << std::endl;
   // Nef_polyhedron::Vertex_const_iterator v;
   // for (v = output->vertices_begin(); v != output->vertices_end(); v++)
-  //   std::cout << v->point() << std::endl;
+  //   *val3ditycout << v->point() << std::endl;
   return output;
 }
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1763,7 +1763,7 @@ json get_report_json(std::string ifile,
   char buffer[80];
   std::strftime(buffer, 80, "%FT%T (%Z)", localTime);
   jr["time"] = buffer;
-  //-- user-defined param
+  //-- user-defined params
   jr["parameters"];
   jr["parameters"]["snap_tol"] = snap_tol;
   jr["parameters"]["overlap_tol"] = overlap_tol;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -40,6 +40,7 @@
 #include "CompositeSolid.h"
 #include "MultiSolid.h"
 #include "GeometryTemplate.h"
+#include "val3dity_ostream.h"
 
 
 using namespace std;
@@ -83,7 +84,7 @@ std::set<int> IOErrors::get_unique_error_codes()
 void IOErrors::add_error(int code, std::string info)
 {
   _errors[code].push_back(info);
-  std::cout << "ERROR " << code << " : " << info << std::endl;
+  *val3ditycout << "ERROR " << code << " : " << info << std::endl;
 }
 
 
@@ -613,17 +614,17 @@ void read_file_json(std::string &ifile, std::vector<Feature*>& lsFeatures, IOErr
   } 
   else if (j["type"] == "tu3djson") {
     errs.set_input_file_type("tu3djson");
-    std::cout << "tu3djson input file" << std::endl;
-    std::cout << "# Features found: " << j["features"].size() << std::endl;
+    *val3ditycout << "tu3djson input file" << std::endl;
+    *val3ditycout << "# Features found: " << j["features"].size() << std::endl;
     parse_tu3djson(j, lsFeatures, tol_snap);
   }
   else if ( (j["type"] == "Feature") || (j["type"] == "FeatureCollection") ) {
     errs.set_input_file_type("JSON-FG");
-    std::cout << "JSON-FG input file" << std::endl;
+    *val3ditycout << "JSON-FG input file" << std::endl;
     if (j["type"] == "Feature")
-      std::cout << "# Features found: " << j["features"].size() << std::endl;
+      *val3ditycout << "# Features found: " << j["features"].size() << std::endl;
     else
-      std::cout << "# Features found: " << j["features"].size() << std::endl;
+      *val3ditycout << "# Features found: " << j["features"].size() << std::endl;
     parse_jsonfg(j, lsFeatures, tol_snap, errs);
   }
   else {
@@ -634,7 +635,7 @@ void read_file_json(std::string &ifile, std::vector<Feature*>& lsFeatures, IOErr
 
 void read_file_jsonl(std::string &ifile, std::vector<Feature*>& lsFeatures, IOErrors& errs, double tol_snap)
 {
-  std::cout << "CityJSONL input file" << std::endl;
+  *val3ditycout << "CityJSONL input file" << std::endl;
   std::ifstream infile(ifile.c_str(), std::ifstream::in);
   if (!infile)
   {
@@ -683,8 +684,8 @@ void read_file_jsonl(std::string &ifile, std::vector<Feature*>& lsFeatures, IOEr
 
 void parse_cityjson(json& j, std::vector<Feature*>& lsFeatures, double tol_snap)
 {
-  std::cout << "CityJSON input file" << std::endl;
-  std::cout << "# City Objects found: " << j["CityObjects"].size() << std::endl;
+  *val3ditycout << "CityJSON input file" << std::endl;
+  *val3ditycout << "# City Objects found: " << j["CityObjects"].size() << std::endl;
   //-- compute (_minx, _miny)
   compute_min_xy(j);
   //-- read and store the GeometryTemplates
@@ -840,7 +841,7 @@ void process_gml_file_indoorgml(pugi::xml_document& doc, std::vector<Feature*>& 
     std::string duality = "";
     //-- get the ID
     if (cs.attribute("gml:id") != 0) {
-      // std::cout << "\t" << it->node().attribute("gml:id").value() << std::endl;
+      // *val3ditycout << "\t" << it->node().attribute("gml:id").value() << std::endl;
       theid = cs.attribute("gml:id").value();
     }
     else 
@@ -868,7 +869,7 @@ void process_gml_file_indoorgml(pugi::xml_document& doc, std::vector<Feature*>& 
         s = NS["gml"] + "Solid";
         for (pugi::xml_node child3 : child2.children(s.c_str()))
         {
-          // std::cout << "Solid: " << child3.attribute("gml:id").value() << std::endl;
+          // *val3ditycout << "Solid: " << child3.attribute("gml:id").value() << std::endl;
           sol = process_gml_solid(child3, dallpoly, tol_snap, errs);
           if (sol->get_id() == "")
             sol->set_id("MISSING_ID");
@@ -919,7 +920,7 @@ void process_gml_file_indoorgml(pugi::xml_document& doc, std::vector<Feature*>& 
 //    pugi::xpath_node_set nstate = doc.select_nodes(s.c_str());
     for (pugi::xpath_node_set::const_iterator it = nstate.begin(); it != nstate.end(); ++it)
     {
-      // std::cout << "---\n" << it->node().attribute("gml:id").value() << std::endl;
+      // *val3ditycout << "---\n" << it->node().attribute("gml:id").value() << std::endl;
       std::string vid = it->node().attribute("gml:id").value();
       s = NS["indoorgml"] + "duality";
       std::string vdual;
@@ -928,7 +929,7 @@ void process_gml_file_indoorgml(pugi::xml_document& doc, std::vector<Feature*>& 
         vdual = child.attribute("xlink:href").value();
         if (vdual[0] == '#')
           vdual = vdual.substr(1);
-        // std::cout << "dual node: " << vdual << std::endl;
+        // *val3ditycout << "dual node: " << vdual << std::endl;
       }
       s = NS["indoorgml"] + "connects";
       std::vector<std::string> vadj;
@@ -944,7 +945,7 @@ void process_gml_file_indoorgml(pugi::xml_document& doc, std::vector<Feature*>& 
       }
       s = ".//" + NS["gml"] + "pos";
       pugi::xpath_node n = it->node().select_node(s.c_str());
-      // std::cout << n.node().child_value() << std::endl;
+      // *val3ditycout << n.node().child_value() << std::endl;
       
       std::string buf;
       std::stringstream ss(n.node().child_value());
@@ -965,7 +966,7 @@ void process_gml_file_indoorgml(pugi::xml_document& doc, std::vector<Feature*>& 
     im->add_graph(ig);
   }
   // if (im->get_number_graphs() == 0)
-  //   std::cout << "\t!!! No dual graph was found in the input file" << std::endl;
+  //   *val3ditycout << "\t!!! No dual graph was found in the input file" << std::endl;
 }
 
 
@@ -973,7 +974,7 @@ void set_min_xy(double minx, double miny)
 {
   _minx = minx;
   _miny = miny;
-  // std::cout << "Translating all coordinates by (-" << _minx << ", -" << _miny << ")" << std::endl;
+  // *val3ditycout << "Translating all coordinates by (-" << _minx << ", -" << _miny << ")" << std::endl;
   Primitive::set_translation_min_values(_minx, _miny);
   Surface::set_translation_min_values(_minx, _miny);
 }
@@ -992,7 +993,7 @@ void compute_min_xy(json& j)
     _minx = (_minx * double(j["transform"]["scale"][0])) + double(j["transform"]["translate"][0]);
     _miny = (_miny * double(j["transform"]["scale"][1])) + double(j["transform"]["translate"][1]);
   }
-  // std::cout << "Translating all coordinates by (-" << _minx << ", -" << _miny << ")" << std::endl;
+  // *val3ditycout << "Translating all coordinates by (-" << _minx << ", -" << _miny << ")" << std::endl;
   Primitive::set_translation_min_values(_minx, _miny);
   Surface::set_translation_min_values(_minx, _miny);
 }
@@ -1031,7 +1032,7 @@ void compute_min_xy(pugi::xml_document& doc)
     if (std::stod(tokens[1]) < _miny)
       _miny = std::stod(tokens[1]);
   }
-  // std::cout << "Translating all coordinates by (-" << _minx << ", -" << _miny << ")" << std::endl;
+  // *val3ditycout << "Translating all coordinates by (-" << _minx << ", -" << _miny << ")" << std::endl;
   Primitive::set_translation_min_values(_minx, _miny);
   Surface::set_translation_min_values(_minx, _miny);
 }
@@ -1039,7 +1040,7 @@ void compute_min_xy(pugi::xml_document& doc)
 
 void read_file_gml(std::string &ifile, std::vector<Feature*>& lsFeatures, IOErrors& errs, double tol_snap)
 {
-  std::cout << "Reading file: " << ifile << std::endl;
+  *val3ditycout << "Reading file: " << ifile << std::endl;
   pugi::xml_document doc;
   pugi::xml_parse_result result = doc.load_file(ifile.c_str());
   if (!result) {
@@ -1053,7 +1054,7 @@ void read_file_gml(std::string &ifile, std::vector<Feature*>& lsFeatures, IOErro
   pugi::xml_node ncm = doc.first_child();
   get_namespaces(ncm); //-- results in global variable NS in this unit
   if ( (NS.count("indoorgml") != 0) && (ncm.name() == (NS["indoorgml"] + "IndoorFeatures")) ) {
-    std::cout << "IndoorGML input file" << std::endl;
+    *val3ditycout << "IndoorGML input file" << std::endl;
     //-- find (_minx, _miny)
     compute_min_xy(doc);
     //-- build dico of xlinks for <gml:Polygon>
@@ -1072,7 +1073,7 @@ std::map<std::string, std::string> get_namespaces(pugi::xml_node& root) {
   for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
     std::string name = attr.name();
     if (name.find("xmlns") != std::string::npos) {
-      // std::cout << attr.name() << "=" << attr.value() << std::endl;
+      // *val3ditycout << attr.name() << "=" << attr.value() << std::endl;
       std::string value = attr.value();
       std::string sns;
       if (value.find("http://www.opengis.net/citygml/") != std::string::npos) {
@@ -1109,7 +1110,7 @@ void build_dico_xlinks(pugi::xml_document& doc, std::map<std::string, pugi::xpat
   std::string s = "//" + NS["gml"] + "Polygon" + "[@" + NS["gml"] + "id]";
   pugi::xpath_node_set nallpoly = doc.select_nodes(s.c_str());
   if (nallpoly.size() > 0)
-   std::cout << "XLinks found, resolving them..." << std::flush;
+   *val3ditycout << "XLinks found, resolving them..." << std::flush;
   for (pugi::xpath_node_set::const_iterator it = nallpoly.begin(); it != nallpoly.end(); ++it)
     dallpoly[it->node().attribute("gml:id").value()] = *it;
   //-- for <gml:OrientableSurface>
@@ -1135,7 +1136,7 @@ void build_dico_xlinks(pugi::xml_document& doc, std::map<std::string, pugi::xpat
     }
   }
   if (nallpoly.size() > 0)
-    std::cout << "done." << std::endl;
+    *val3ditycout << "done." << std::endl;
 }
 
 
@@ -1155,7 +1156,7 @@ Surface* parse_poly(std::istream &input, int shellid, IOErrors& errs)
     if (y < _miny)
       _miny = y;
   }
-  std::cout << "Translating all coordinates by (-" << _minx << ", -" << _miny << ")" << std::endl;
+  *val3ditycout << "Translating all coordinates by (-" << _minx << ", -" << _miny << ")" << std::endl;
   Primitive::set_translation_min_values(_minx, _miny);
   Surface::set_translation_min_values(_minx, _miny);
   input.clear();
@@ -1232,9 +1233,9 @@ void printProgressBar(int percent) {
       bar.replace(i, 1, " ");
     }
   }
-  std::cout << "\r" "[" << bar << "] ";
-  std::cout.width(3);
-  std::cout << percent << "%     " << std::flush;
+  *val3ditycout << "\r" "[" << bar << "] ";
+  (*val3ditycout).width(3);
+  *val3ditycout << percent << "%     " << std::flush;
 }
 
 
@@ -1259,7 +1260,7 @@ Surface* parse_off(std::istream &input, int shellid, IOErrors& errs, double tol_
     if (y < _miny)
       _miny = y;
   }
-  std::cout << "Translating all coordinates by (-" << _minx << ", -" << _miny << ")" << std::endl;
+  *val3ditycout << "Translating all coordinates by (-" << _minx << ", -" << _miny << ")" << std::endl;
   Primitive::set_translation_min_values(_minx, _miny);
   Surface::set_translation_min_values(_minx, _miny);
   //-- reset the file
@@ -1319,7 +1320,7 @@ void parse_obj(std::istream &input, std::vector<Feature*>& lsFeatures, Primitive
         _miny = y;
     }
   }
-  std::cout << "Translating all coordinates by (-" << _minx << ", -" << _miny << ")" << std::endl;
+  *val3ditycout << "Translating all coordinates by (-" << _minx << ", -" << _miny << ")" << std::endl;
   Primitive::set_translation_min_values(_minx, _miny);
   Surface::set_translation_min_values(_minx, _miny);
   //-- read again file and parse everything

--- a/src/input.h
+++ b/src/input.h
@@ -106,7 +106,7 @@ struct primitives_walker: pugi::xml_tree_walker
   virtual bool for_each(pugi::xml_node& node)
   { 
     const char *nodeType = node.name();
-    // std::cout << node.name() << std::endl;
+    // *val3ditycout << node.name() << std::endl;
     const char *namespaceSeparator = strchr(nodeType, ':');
     bool gmlboundedBy = false;
     //-- hack with namespace "gml:" hardcoded... with namespace list == I don't know how
@@ -117,7 +117,7 @@ struct primitives_walker: pugi::xml_tree_walker
     }
     if (depth() == depthprim)
     {
-      // std::cout << "back to reading mode -- " << node.name() << std::endl;
+      // *val3ditycout << "back to reading mode -- " << node.name() << std::endl;
       depthprim = 999;
     }
     if ((strcmp(nodeType, "boundedBy") == 0) && (gmlboundedBy == false))
@@ -130,8 +130,8 @@ struct primitives_walker: pugi::xml_tree_walker
            ( (strcmp(nodeType, "boundedBy") == 0) && (gmlboundedBy == false) )||
            (strcmp(nodeType, "CompositeSurface") == 0) ) )
     {
-      // std::cout << "----" << node.name() << std::endl;
-      // std::cout << "depth " << depth() << std::endl;
+      // *val3ditycout << "----" << node.name() << std::endl;
+      // *val3ditycout << "depth " << depth() << std::endl;
       depthprim = depth();
       lsNodes.push_back(node);
     }

--- a/src/val3dity.cpp
+++ b/src/val3dity.cpp
@@ -52,74 +52,74 @@ struct verror : std::exception {
 
 json
 validate_onegeom(json& j,
-                 Parameters param)
+                 Parameters params)
 {
   std::vector<Feature*> lsFeatures;
-  parse_tu3djson_onegeom(j, lsFeatures, param._tol_snap);
+  parse_tu3djson_onegeom(j, lsFeatures, params._tol_snap);
   //-- validate
   for (auto& f : lsFeatures)
-      f->validate(param._planarity_d2p_tol, param._planarity_n_tol, param._overlap_tol);
+      f->validate(params._planarity_d2p_tol, params._planarity_n_tol, params._overlap_tol);
   //-- get report in json
   IOErrors ioerrs;
   ioerrs.set_input_file_type("tu3djson_geom");
   json jr = get_report_json("JSON object",
                             lsFeatures,
                             VAL3DITY_VERSION,
-                            param._tol_snap,
-                            param._overlap_tol,
-                            param._planarity_d2p_tol,
-                            param._planarity_n_tol,
+                            params._tol_snap,
+                            params._overlap_tol,
+                            params._planarity_d2p_tol,
+                            params._planarity_n_tol,
                             ioerrs);
   return jr;
 }
 
 json validate_jsonfg(json& j,
-                     Parameters param)
+                     Parameters params)
 {
   IOErrors ioerrs;
   ioerrs.set_input_file_type("JSON-FG");
   std::vector<Feature*> lsFeatures;
-  parse_jsonfg(j, lsFeatures, param._tol_snap, ioerrs);
+  parse_jsonfg(j, lsFeatures, params._tol_snap, ioerrs);
   //-- validate
   for (auto& f : lsFeatures)
-      f->validate(param._planarity_d2p_tol, param._planarity_n_tol, param._overlap_tol);
+      f->validate(params._planarity_d2p_tol, params._planarity_n_tol, params._overlap_tol);
   //-- get report in json
   json jr = get_report_json("JSON object",
                             lsFeatures,
                             VAL3DITY_VERSION,
-                            param._tol_snap,
-                            param._overlap_tol,
-                            param._planarity_d2p_tol,
-                            param._planarity_n_tol,
+                            params._tol_snap,
+                            params._overlap_tol,
+                            params._planarity_d2p_tol,
+                            params._planarity_n_tol,
                             ioerrs);
   return jr;
 }
 
 json validate_tu3djson(json& j,
-                       Parameters param)
+                       Parameters params)
 {
   std::vector<Feature*> lsFeatures;
-  parse_tu3djson(j, lsFeatures, param._tol_snap);
+  parse_tu3djson(j, lsFeatures, params._tol_snap);
   //-- validate
   for (auto& f : lsFeatures)
-      f->validate(param._planarity_d2p_tol, param._planarity_n_tol, param._overlap_tol);
+      f->validate(params._planarity_d2p_tol, params._planarity_n_tol, params._overlap_tol);
   //-- get report in json
   IOErrors ioerrs;
   ioerrs.set_input_file_type("tu3djson");
   json jr = get_report_json("JSON object",
                             lsFeatures,
                             VAL3DITY_VERSION,
-                            param._tol_snap,
-                            param._overlap_tol,
-                            param._planarity_d2p_tol,
-                            param._planarity_n_tol,
+                            params._tol_snap,
+                            params._overlap_tol,
+                            params._planarity_d2p_tol,
+                            params._planarity_n_tol,
                             ioerrs);
   return jr;
 }
 
 json
 validate_cityjson(json& j,
-                  Parameters param)
+                  Parameters params)
 {
   std::vector<Feature*> lsFeatures;
   //-- parse the cityjson object
@@ -129,7 +129,7 @@ validate_cityjson(json& j,
   std::vector<GeometryTemplate*> lsGTs;
   if (j.count("geometry-templates") == 1)
   {
-      process_cityjson_geometrytemplates(j["geometry-templates"], lsGTs, param._tol_snap);
+      process_cityjson_geometrytemplates(j["geometry-templates"], lsGTs, params._tol_snap);
   }
   //-- process each CO
   for (json::iterator it = j["CityObjects"].begin(); it != j["CityObjects"].end(); ++it)
@@ -138,20 +138,20 @@ validate_cityjson(json& j,
       if (it.value()["type"] == "BuildingPart")
           continue;
       CityObject* co = new CityObject(it.key(), it.value()["type"]);
-      process_json_geometries_of_co(it.value(), co, lsGTs, j, param._tol_snap);
+      process_json_geometries_of_co(it.value(), co, lsGTs, j, params._tol_snap);
       //-- if Building has Parts, put them here in _lsPrimitives
       if ( (it.value()["type"] == "Building") && (it.value().count("children") != 0) )
       {
           for (std::string bpid : it.value()["children"])
           {
-              process_json_geometries_of_co(j["CityObjects"][bpid], co, lsGTs, j, param._tol_snap);
+              process_json_geometries_of_co(j["CityObjects"][bpid], co, lsGTs, j, params._tol_snap);
           }
       }
       lsFeatures.push_back(co);
   }
   //-- validate
   for (auto& f : lsFeatures)
-      f->validate(param._planarity_d2p_tol, param._planarity_n_tol, param._overlap_tol);
+      f->validate(params._planarity_d2p_tol, params._planarity_n_tol, params._overlap_tol);
   //-- compile errors
   std::set<int> errors;
   for (auto& f : lsFeatures)
@@ -164,17 +164,17 @@ validate_cityjson(json& j,
   json jr = get_report_json("JSON object",
                             lsFeatures,
                             VAL3DITY_VERSION,
-                            param._tol_snap,
-                            param._overlap_tol,
-                            param._planarity_d2p_tol,
-                            param._planarity_n_tol,
+                            params._tol_snap,
+                            params._overlap_tol,
+                            params._planarity_d2p_tol,
+                            params._planarity_n_tol,
                             ioerrs);
   return jr;
 }
 
 json
 validate_cityjsonfeature(json& j,
-                         Parameters param)
+                         Parameters params)
 {
   // j["transform"] = jtransform;
   std::vector<Feature*> lsFeatures;
@@ -189,20 +189,20 @@ validate_cityjsonfeature(json& j,
       if (it.value()["type"] == "BuildingPart")
           continue;
       CityObject* co = new CityObject(it.key(), it.value()["type"]);
-      process_json_geometries_of_co(it.value(), co, lsGTs, j, param._tol_snap);
+      process_json_geometries_of_co(it.value(), co, lsGTs, j, params._tol_snap);
       //-- if Building has Parts, put them here in _lsPrimitives
       if ( (it.value()["type"] == "Building") && (it.value().count("children") != 0) )
       {
           for (std::string bpid : it.value()["children"])
           {
-              process_json_geometries_of_co(j["CityObjects"][bpid], co, lsGTs, j, param._tol_snap);
+              process_json_geometries_of_co(j["CityObjects"][bpid], co, lsGTs, j, params._tol_snap);
           }
       }
       lsFeatures.push_back(co);
   }
   //-- validate
   for (auto& f : lsFeatures)
-      f->validate(param._planarity_d2p_tol, param._planarity_n_tol, param._overlap_tol);
+      f->validate(params._planarity_d2p_tol, params._planarity_n_tol, params._overlap_tol);
   //-- compile errors
   std::set<int> errors;
   for (auto& f : lsFeatures)
@@ -215,17 +215,17 @@ validate_cityjsonfeature(json& j,
   json jr = get_report_json("JSON object",
                             lsFeatures,
                             VAL3DITY_VERSION,
-                            param._tol_snap,
-                            param._overlap_tol,
-                            param._planarity_d2p_tol,
-                            param._planarity_n_tol,
+                            params._tol_snap,
+                            params._overlap_tol,
+                            params._planarity_d2p_tol,
+                            params._planarity_n_tol,
                             ioerrs);
   return jr;
 }
 
 json
 validate_indoorgml(std::string& input,
-                   Parameters param)
+                   Parameters params)
 {
   IOErrors ioerrs;
   ioerrs.set_input_file_type("IndoorGML");
@@ -246,7 +246,7 @@ validate_indoorgml(std::string& input,
           std::map<std::string, pugi::xpath_node> dallpoly;
           build_dico_xlinks(doc, dallpoly, ioerrs);
           ioerrs.set_input_file_type("IndoorGML");
-          process_gml_file_indoorgml(doc, lsFeatures, dallpoly, ioerrs, param._tol_snap);
+          process_gml_file_indoorgml(doc, lsFeatures, dallpoly, ioerrs, params._tol_snap);
       }
       else
       {
@@ -257,57 +257,57 @@ validate_indoorgml(std::string& input,
   if (ioerrs.has_errors() == false) {
       //-- validate
       for (auto& f : lsFeatures)
-          f->validate(param._planarity_d2p_tol, param._planarity_n_tol, param._overlap_tol);
+          f->validate(params._planarity_d2p_tol, params._planarity_n_tol, params._overlap_tol);
   }
   //-- get report in json
   json jr = get_report_json("JSON object",
                             lsFeatures,
                             VAL3DITY_VERSION,
-                            param._tol_snap,
-                            param._overlap_tol,
-                            param._planarity_d2p_tol,
-                            param._planarity_n_tol,
+                            params._tol_snap,
+                            params._overlap_tol,
+                            params._planarity_d2p_tol,
+                            params._planarity_n_tol,
                             ioerrs);
   return jr;
 }
 
 json
 validate_obj(std::string& input,
-             Parameters param)
+             Parameters params)
 {
   IOErrors ioerrs;
   ioerrs.set_input_file_type("OBJ");
   std::vector<Feature*> lsFeatures;
   std::istringstream iss(input);
-  parse_obj(iss, lsFeatures, SOLID, ioerrs, param._tol_snap);
+  parse_obj(iss, lsFeatures, SOLID, ioerrs, params._tol_snap);
   //-- start the validation
   if (ioerrs.has_errors() == false) {
       //-- validate
       for (auto& f : lsFeatures)
-          f->validate(param._planarity_d2p_tol, param._planarity_n_tol, param._overlap_tol);
+          f->validate(params._planarity_d2p_tol, params._planarity_n_tol, params._overlap_tol);
   }
   //-- get report in json
   json jr = get_report_json("OBJ object",
                             lsFeatures,
                             VAL3DITY_VERSION,
-                            param._tol_snap,
-                            param._overlap_tol,
-                            param._planarity_d2p_tol,
-                            param._planarity_n_tol,
+                            params._tol_snap,
+                            params._overlap_tol,
+                            params._planarity_d2p_tol,
+                            params._planarity_n_tol,
                             ioerrs);
   return jr;
 }
 
 json
 validate_off(std::string& input,
-             Parameters param)
+             Parameters params)
 {
   IOErrors ioerrs;
   ioerrs.set_input_file_type("OFF");
   std::vector<Feature*> lsFeatures;
   GenericObject* o = new GenericObject("none");
   std::istringstream iss(input);
-  Surface* sh = parse_off(iss, 0, ioerrs, param._tol_snap);
+  Surface* sh = parse_off(iss, 0, ioerrs, params._tol_snap);
   std::cout << "1" << std::endl;
   Solid* s = new Solid;
   s->set_oshell(sh);
@@ -321,17 +321,17 @@ validate_off(std::string& input,
   // if (ioerrs.has_errors() == false) {
   //-- validate
   for (auto& f : lsFeatures)
-      f->validate(param._planarity_d2p_tol, param._planarity_n_tol, param._overlap_tol);
+      f->validate(params._planarity_d2p_tol, params._planarity_n_tol, params._overlap_tol);
   // }
   std::cout << "2" << std::endl;
   //-- get report in json
   json jr = get_report_json("OFF object",
                             lsFeatures,
                             VAL3DITY_VERSION,
-                            param._tol_snap,
-                            param._overlap_tol,
-                            param._planarity_d2p_tol,
-                            param._planarity_n_tol,
+                            params._tol_snap,
+                            params._overlap_tol,
+                            params._planarity_d2p_tol,
+                            params._planarity_n_tol,
                             ioerrs);
   std::cout << "3" << std::endl;
   return jr;
@@ -339,42 +339,41 @@ validate_off(std::string& input,
 
 bool
 is_valid(json& j,
-         Parameters param)
+         Parameters params)
 {
-  json re = validate(j, param);
+  json re = validate(j, params);
   return re["validity"];
 }
 
 json 
 validate(json& j,
-         Parameters param)
+         Parameters params)
 {
-  std::streambuf* clog_buf = std::clog.rdbuf();
-  std::clog.rdbuf(NULL);
-  std::streambuf* cout_buf = std::cout.rdbuf();
-  std::cout.rdbuf(NULL);
+  std::ostream val3ditycout(set_cout(params._terminal_output).get());
+  std::ostream val3dityclog(set_clog(params._terminal_output).get());
+
   json re;
   //-- CityJSON
   if (j["type"] == "CityJSON") {
-    json jr = validate_cityjson(j, param);
+    json jr = validate_cityjson(j, params);
     re = jr;
   
   //-- CityJSONFeature
   } else if (j["type"] == "CityJSONFeature") {
-    json jr = validate_cityjsonfeature(j, param);
+    json jr = validate_cityjsonfeature(j, params);
     re = jr;
   
   //-- tu3djson
   } else if (j["type"] == "tu3djson") {
-    json jr = validate_tu3djson(j, param);
+    json jr = validate_tu3djson(j, params);
     re = jr;
   
   //-- JSON-FG
   } else if (j["type"] == "Feature") { 
-    json jr = validate_jsonfg(j, param);
+    json jr = validate_jsonfg(j, params);
     re = jr;
   } else if (j["type"] == "FeatureCollection") { 
-    json jr = validate_jsonfg(j, param);
+    json jr = validate_jsonfg(j, params);
     re = jr;
 
   //-- tu3djson onegeom
@@ -383,38 +382,33 @@ validate(json& j,
               (j["type"] == "Solid") ||
               (j["type"] == "MultiSolid") ||
               (j["type"] == "CompositeSolid") ) { 
-    json jr = validate_onegeom(j, param);
+    json jr = validate_onegeom(j, params);
     re = jr;
 
   //-- then we don't support it   
   } else {
-    std::clog.rdbuf(clog_buf);
-    std::cout.rdbuf(cout_buf);
     throw verror("Flavour of JSON not supported");
   }  
-  std::clog.rdbuf(clog_buf);
-  std::cout.rdbuf(cout_buf);
   return re;
 }
 
 bool 
 is_valid(const std::vector<std::array<double, 3>>& vertices,
          const std::vector<std::vector<int>>& faces,
-         Parameters param)
+         Parameters params)
 {
-  json re = validate(vertices, faces, param);
+  json re = validate(vertices, faces, params);
   return re["validity"];
 }
 
 json
 validate(const std::vector<std::array<double, 3>>& vertices,
          const std::vector<std::vector<int>>& faces,
-         Parameters param)
+         Parameters params)
 {
-  std::streambuf* clog_buf = std::clog.rdbuf();
-  std::clog.rdbuf(NULL);
-  std::streambuf* cout_buf = std::cout.rdbuf();
-  std::cout.rdbuf(NULL);
+  std::ostream val3ditycout(set_cout(params._terminal_output).get());
+  std::ostream val3dityclog(set_clog(params._terminal_output).get());
+
   double _minx = 9e15;
   double _miny = 9e15; 
   //-- find (minx, miny)
@@ -425,7 +419,7 @@ validate(const std::vector<std::array<double, 3>>& vertices,
       _miny = v[1];
   }
   //-- create a Surface (a 2-manifold)
-  Surface* sh = new Surface(0, param._tol_snap);
+  Surface* sh = new Surface(0, params._tol_snap);
   std::vector<Point3*> allvertices;
   GenericObject* o = new GenericObject("none");
   //-- read all the vertices
@@ -448,7 +442,7 @@ validate(const std::vector<std::array<double, 3>>& vertices,
   Solid* sol = new Solid("");
   sol->set_oshell(sh);
   o->add_primitive(sol);
-  o->validate(param._planarity_d2p_tol, param._planarity_n_tol, param._overlap_tol);
+  o->validate(params._planarity_d2p_tol, params._planarity_n_tol, params._overlap_tol);
   IOErrors ioerrs;
   ioerrs.set_input_file_type("std::vectors");
   std::vector<Feature*> lsFeatures;
@@ -456,13 +450,11 @@ validate(const std::vector<std::array<double, 3>>& vertices,
   json jr = get_report_json("std::vectors",
                             lsFeatures,
                             VAL3DITY_VERSION,
-                            param._tol_snap,
-                            param._overlap_tol,
-                            param._planarity_d2p_tol,
-                            param._planarity_n_tol,
+                            params._tol_snap,
+                            params._overlap_tol,
+                            params._planarity_d2p_tol,
+                            params._planarity_n_tol,
                             ioerrs);
-  std::clog.rdbuf(clog_buf);
-  std::cout.rdbuf(cout_buf);
   return jr;
 }
 
@@ -470,41 +462,35 @@ validate(const std::vector<std::array<double, 3>>& vertices,
 bool 
 is_valid(std::string& input,
          std::string format,
-         Parameters param)
+         Parameters params)
 {
-  json re = validate(input, format, param);
+  json re = validate(input, format, params);
   return re["validity"];
 }
 
 json
 validate(std::string& input,
          std::string format,
-         Parameters param)
+         Parameters params)
 {
-  std::streambuf* clog_buf = std::clog.rdbuf();
-  std::clog.rdbuf(NULL);
-  std::streambuf* cout_buf = std::cout.rdbuf();
-  std::cout.rdbuf(NULL);
+  std::ostream val3ditycout(set_cout(params._terminal_output).get());
+  std::ostream val3dityclog(set_clog(params._terminal_output).get());
   json re;
   if (format == "IndoorGML") {
-    json j = validate_indoorgml(input, param);
+    json j = validate_indoorgml(input, params);
     re = j;
   }
   else if (format == "OBJ") {
-    json j = validate_obj(input, param);
+    json j = validate_obj(input, params);
     re = j;
   }
   else if (format == "OFF") {
-    json j = validate_off(input, param);
+    json j = validate_off(input, params);
     re = j;
   }
   else { 
-    std::clog.rdbuf(clog_buf);
-    std::cout.rdbuf(cout_buf);
     throw verror("File type not supported");
   }
-  std::clog.rdbuf(clog_buf);
-  std::cout.rdbuf(cout_buf);
   return re;
 }
 

--- a/src/val3dity.cpp
+++ b/src/val3dity.cpp
@@ -37,11 +37,13 @@
 
 #include <exception>      // std::exception
 
-namespace val3dity {
+namespace val3dity
+{
 
 std::string VAL3DITY_VERSION = "2.4.1b0";
 
-struct verror : std::exception {
+struct verror : std::exception
+{
   std::string whattext;
   verror(std::string s) : whattext(s){};
   const char* what() const noexcept {return whattext.c_str();}
@@ -346,8 +348,7 @@ json
 validate(json& j,
          Parameters params)
 {
-    terminal_output(params._terminal_output);
-
+  terminal_output(params._terminal_output);
   json re;
   //-- CityJSON
   if (j["type"] == "CityJSON") {
@@ -402,8 +403,7 @@ validate(const std::vector<std::array<double, 3>>& vertices,
          const std::vector<std::vector<int>>& faces,
          Parameters params)
 {
-    terminal_output(params._terminal_output);
-
+  terminal_output(params._terminal_output);
   double _minx = 9e15;
   double _miny = 9e15; 
   //-- find (minx, miny)
@@ -468,7 +468,7 @@ validate(std::string& input,
          std::string format,
          Parameters params)
 {
-    terminal_output(params._terminal_output);
+  terminal_output(params._terminal_output);
   json re;
   if (format == "IndoorGML") {
     json j = validate_indoorgml(input, params);
@@ -488,4 +488,4 @@ validate(std::string& input,
   return re;
 }
 
-}
+} // namespace val3dity

--- a/src/val3dity.cpp
+++ b/src/val3dity.cpp
@@ -346,7 +346,7 @@ json
 validate(json& j,
          Parameters params)
 {
-  output_terminal(params._terminal_output);
+    terminal_output(params._terminal_output);
 
   json re;
   //-- CityJSON
@@ -402,7 +402,7 @@ validate(const std::vector<std::array<double, 3>>& vertices,
          const std::vector<std::vector<int>>& faces,
          Parameters params)
 {
-  output_terminal(params._terminal_output);
+    terminal_output(params._terminal_output);
 
   double _minx = 9e15;
   double _miny = 9e15; 
@@ -468,7 +468,7 @@ validate(std::string& input,
          std::string format,
          Parameters params)
 {
-  output_terminal(params._terminal_output);
+    terminal_output(params._terminal_output);
   json re;
   if (format == "IndoorGML") {
     json j = validate_indoorgml(input, params);

--- a/src/val3dity.cpp
+++ b/src/val3dity.cpp
@@ -37,10 +37,29 @@
 #include <iostream>
 #include <exception>      // std::exception
 
+namespace val3dity {
 
+//todo move these somewhere else
+NullBuffer::int_type NullBuffer::overflow(int_type c) {
+    return traits_type::not_eof(c);
+}
 
-namespace val3dity
-{
+NullBuffer nullBuffer;
+std::ostream nullStream(&nullBuffer);
+std::ostream* val3ditycout = &nullStream; //&std::cout;
+std::ostream* val3dityclog = &nullStream; //&std::cout;
+
+void output_terminal(bool output_terminal) {
+    if (output_terminal) {
+//        val3ditycout = &std::cout;
+//        val3dityclog = &std::clog;
+        val3ditycout = &nullStream;
+        val3dityclog = &nullStream;
+    } else {
+        val3ditycout = &nullStream;
+        val3dityclog = &nullStream;
+    }
+}
 
 std::string VAL3DITY_VERSION = "2.4.1b0";
 
@@ -349,8 +368,7 @@ json
 validate(json& j,
          Parameters params)
 {
-  std::ostream val3ditycout(set_cout(params._terminal_output).get());
-  std::ostream val3dityclog(set_clog(params._terminal_output).get());
+  output_terminal(params._terminal_output);
 
   json re;
   //-- CityJSON
@@ -406,8 +424,7 @@ validate(const std::vector<std::array<double, 3>>& vertices,
          const std::vector<std::vector<int>>& faces,
          Parameters params)
 {
-  std::ostream val3ditycout(set_cout(params._terminal_output).get());
-  std::ostream val3dityclog(set_clog(params._terminal_output).get());
+  output_terminal(params._terminal_output);
 
   double _minx = 9e15;
   double _miny = 9e15; 
@@ -473,8 +490,7 @@ validate(std::string& input,
          std::string format,
          Parameters params)
 {
-  std::ostream val3ditycout(set_cout(params._terminal_output).get());
-  std::ostream val3dityclog(set_clog(params._terminal_output).get());
+  output_terminal(params._terminal_output);
   json re;
   if (format == "IndoorGML") {
     json j = validate_indoorgml(input, params);

--- a/src/val3dity.cpp
+++ b/src/val3dity.cpp
@@ -33,33 +33,11 @@
 #include "Solid.h"
 #include "Surface.h"
 #include "input.h"
+#include "val3dity_ostream.h"
 
-#include <iostream>
 #include <exception>      // std::exception
 
 namespace val3dity {
-
-//todo move these somewhere else
-NullBuffer::int_type NullBuffer::overflow(int_type c) {
-    return traits_type::not_eof(c);
-}
-
-NullBuffer nullBuffer;
-std::ostream nullStream(&nullBuffer);
-std::ostream* val3ditycout = &nullStream; //&std::cout;
-std::ostream* val3dityclog = &nullStream; //&std::cout;
-
-void output_terminal(bool output_terminal) {
-    if (output_terminal) {
-//        val3ditycout = &std::cout;
-//        val3dityclog = &std::clog;
-        val3ditycout = &nullStream;
-        val3dityclog = &nullStream;
-    } else {
-        val3ditycout = &nullStream;
-        val3dityclog = &nullStream;
-    }
-}
 
 std::string VAL3DITY_VERSION = "2.4.1b0";
 
@@ -327,22 +305,22 @@ validate_off(std::string& input,
   GenericObject* o = new GenericObject("none");
   std::istringstream iss(input);
   Surface* sh = parse_off(iss, 0, ioerrs, params._tol_snap);
-  std::cout << "1" << std::endl;
+  *val3ditycout << "1" << std::endl;
   Solid* s = new Solid;
   s->set_oshell(sh);
   o->add_primitive(s);
   lsFeatures.push_back(o);
   //-- start the validation
-  // std::cout << "errors: " << ioerrs.has_errors() << std::endl;
+  // *val3ditycout << "errors: " << ioerrs.has_errors() << std::endl;
   for (auto& each : ioerrs.get_unique_error_codes())
-      std::cout << each << std::endl;
+      *val3ditycout << each << std::endl;
 
   // if (ioerrs.has_errors() == false) {
   //-- validate
   for (auto& f : lsFeatures)
       f->validate(params._planarity_d2p_tol, params._planarity_n_tol, params._overlap_tol);
   // }
-  std::cout << "2" << std::endl;
+  *val3ditycout << "2" << std::endl;
   //-- get report in json
   json jr = get_report_json("OFF object",
                             lsFeatures,
@@ -352,7 +330,7 @@ validate_off(std::string& input,
                             params._planarity_d2p_tol,
                             params._planarity_n_tol,
                             ioerrs);
-  std::cout << "3" << std::endl;
+  *val3ditycout << "3" << std::endl;
   return jr;
 }
 

--- a/src/val3dity.h
+++ b/src/val3dity.h
@@ -25,73 +25,29 @@
   Delft University of Technology
   Julianalaan 134, Delft 2628BL, the Netherlands
 */
+#ifndef val3dity_h
+#define val3dity_h
 
 #include <iostream>
-
 #include "nlohmann-json/json.hpp"
 
 using json = nlohmann::json;
 
 namespace val3dity {
 
-//todo move all this to a separate file
-
-class Val3dityBuffer : public std::streambuf
-{
+//todo move these somewhere else
+class NullBuffer : public std::streambuf {
 protected:
-    virtual int_type overflow(int_type c) = 0;
+    virtual int_type overflow(int_type c);
 };
 
-class CoutRedirectBuffer : public Val3dityBuffer
-{
-protected:
-  // Override the overflow method to handle character output
-  virtual int_type overflow(int_type c) override {
-    if (c != traits_type::eof()) {
-      // Write the character to std::cout
-      std::cout.put(char(c));
-    }
-    return c;
-  }
-};
+extern NullBuffer nullBuffer;
+extern std::ostream nullStream;
+extern std::ostream* val3ditycout;
+extern std::ostream* val3dityclog;
 
-class ClogRedirectBuffer : public Val3dityBuffer
-{
-protected:
-    // Override the overflow method to handle character output
-    virtual int_type overflow(int_type c) override {
-        if (c != traits_type::eof()) {
-            // Write the character to std::clog
-            std::clog.put(char(c));
-        }
-        return c;
-    }
-};
+void output_terminal(bool output_terminal);
 
-
-class NullBuffer : public Val3dityBuffer {
-protected:
-    // Override the overflow method to discard the output
-    virtual int_type overflow(int_type c) override {
-        // Return something other than EOF to signify success
-        return traits_type::not_eof(c);
-    }
-};
-
-std::unique_ptr<Val3dityBuffer> set_cout(bool terminal_output = true)
-{
-  if (terminal_output)
-    return std::make_unique<CoutRedirectBuffer>();
-  else
-    return std::make_unique<NullBuffer>();
-};
-std::unique_ptr<Val3dityBuffer> set_clog(bool terminal_output = true)
-{
-  if (terminal_output)
-    return std::make_unique<ClogRedirectBuffer>();
-  else
-    return std::make_unique<NullBuffer>();
-};
 
 struct Parameters {
     double _tol_snap = 0.001;
@@ -155,3 +111,5 @@ is_valid(const std::vector<std::array<double, 3>>& vertices,
               Parameters params = Parameters());
 
 }
+
+#endif /* val3dity_h */

--- a/src/val3dity.h
+++ b/src/val3dity.h
@@ -31,55 +31,62 @@
 
 using json = nlohmann::json;
 
-namespace val3dity
-{
+namespace val3dity {
+
+struct Parameters {
+    double _tol_snap = 0.001;
+    double _planarity_d2p_tol = 0.01;
+    double _planarity_n_tol = 20.0;
+    double _overlap_tol = -1.0;
+
+    Parameters& tol_snap(double tol_snap) {
+        _tol_snap = tol_snap;
+        return *this;
+    }
+
+    Parameters& planarity_d2p_tol(double planarity_d2p_tol) {
+        _planarity_d2p_tol = planarity_d2p_tol;
+        return *this;
+    }
+
+    Parameters& planarity_n_tol(double planarity_n_tol) {
+        _planarity_n_tol = planarity_n_tol;
+        return *this;
+    }
+
+    Parameters& overlap_tol(double overlap_tol) {
+        _overlap_tol = overlap_tol;
+        return *this;
+    }
+};
 
 
-bool 
-is_valid(json& j,
-         double tol_snap=0.001, 
-         double planarity_d2p_tol=0.01, 
-         double planarity_n_tol=20.0, 
-         double overlap_tol=-1.0);
+bool
+is_valid(json& j, Parameters param = Parameters());
 
 json
-validate(json& j,
-         double tol_snap=0.001, 
-         double planarity_d2p_tol=0.01, 
-         double planarity_n_tol=20.0, 
-         double overlap_tol=-1.0);
+validate(json& j, Parameters param = Parameters());
 
-bool 
+bool
 is_valid(std::string& input,
-         std::string format, 
-         double tol_snap=0.001, 
-         double planarity_d2p_tol=0.01, 
-         double planarity_n_tol=20.0, 
-         double overlap_tol=-1.0);
+              std::string format,
+              Parameters param = Parameters());
 
-json 
+json
 validate(std::string& input,
-         std::string format, 
-         double tol_snap=0.001, 
-         double planarity_d2p_tol=0.01, 
-         double planarity_n_tol=20.0, 
-         double overlap_tol=-1.0);
+              std::string format,
+              Parameters param = Parameters());
 
-json 
+
+json
 validate(const std::vector<std::array<double, 3>>& vertices,
-         const std::vector<std::vector<int>>& triangle_ids,
-         double tol_snap=0.001, 
-         double planarity_d2p_tol=0.01, 
-         double planarity_n_tol=20.0, 
-         double overlap_tol=-1.0);
+              const std::vector<std::vector<int>>& triangle_ids,
+              Parameters param = Parameters());
 
-bool 
+
+bool
 is_valid(const std::vector<std::array<double, 3>>& vertices,
-         const std::vector<std::vector<int>>& triangle_ids,
-         double tol_snap=0.001, 
-         double planarity_d2p_tol=0.01, 
-         double planarity_n_tol=20.0, 
-         double overlap_tol=-1.0);
-
+              const std::vector<std::vector<int>>& triangle_ids,
+              Parameters param = Parameters());
 
 }

--- a/src/val3dity.h
+++ b/src/val3dity.h
@@ -25,6 +25,7 @@
   Delft University of Technology
   Julianalaan 134, Delft 2628BL, the Netherlands
 */
+
 #ifndef val3dity_h
 #define val3dity_h
 
@@ -32,36 +33,43 @@
 
 using json = nlohmann::json;
 
-namespace val3dity {
+namespace val3dity
+{
 
-struct Parameters {
-    double _tol_snap = 0.001;
-    double _planarity_d2p_tol = 0.01;
-    double _planarity_n_tol = 20.0;
-    double _overlap_tol = -1.0;
-    bool _terminal_output = true;
+struct Parameters
+{
+  double _tol_snap = 0.001;
+  double _planarity_d2p_tol = 0.01;
+  double _planarity_n_tol = 20.0;
+  double _overlap_tol = -1.0;
+  bool _terminal_output = true;
 
-    Parameters& tol_snap(double tol_snap) { _tol_snap = tol_snap;
-        return *this;
-    }
-    Parameters& planarity_d2p_tol(double planarity_d2p_tol) {
-        _planarity_d2p_tol = planarity_d2p_tol;
-        return *this;
-    }
-    Parameters& planarity_n_tol(double planarity_n_tol) {
-        _planarity_n_tol = planarity_n_tol;
-        return *this;
-    }
-    Parameters& overlap_tol(double overlap_tol) {
-        _overlap_tol = overlap_tol;
-        return *this;
-    }
-    Parameters& terminal_output(bool terminal_output) {
-        _terminal_output = terminal_output;
-        return *this;
-    }
+  Parameters& tol_snap(double tol_snap)
+  {
+    _tol_snap = tol_snap;
+    return *this;
+  }
+  Parameters& planarity_d2p_tol(double planarity_d2p_tol)
+  {
+    _planarity_d2p_tol = planarity_d2p_tol;
+    return *this;
+  }
+  Parameters& planarity_n_tol(double planarity_n_tol)
+  {
+    _planarity_n_tol = planarity_n_tol;
+    return *this;
+  }
+  Parameters& overlap_tol(double overlap_tol)
+  {
+    _overlap_tol = overlap_tol;
+    return *this;
+  }
+  Parameters& terminal_output(bool terminal_output)
+  {
+    _terminal_output = terminal_output;
+    return *this;
+  }
 };
-
 
 bool
 is_valid(json& j,
@@ -81,18 +89,16 @@ validate(std::string& input,
          std::string format,
          Parameters params = Parameters());
 
-
 json
 validate(const std::vector<std::array<double, 3>>& vertices,
          const std::vector<std::vector<int>>& triangle_ids,
          Parameters params = Parameters());
-
 
 bool
 is_valid(const std::vector<std::array<double, 3>>& vertices,
          const std::vector<std::vector<int>>& triangle_ids,
          Parameters params = Parameters());
 
-}
+} // namespace val3dity
 
 #endif /* val3dity_h */

--- a/src/val3dity.h
+++ b/src/val3dity.h
@@ -64,32 +64,34 @@ struct Parameters {
 
 
 bool
-is_valid(json& j, Parameters params = Parameters());
+is_valid(json& j,
+         Parameters params = Parameters());
 
 json
-validate(json& j, Parameters params = Parameters());
+validate(json& j,
+         Parameters params = Parameters());
 
 bool
 is_valid(std::string& input,
-              std::string format,
-              Parameters params = Parameters());
+         std::string format,
+         Parameters params = Parameters());
 
 json
 validate(std::string& input,
-              std::string format,
-              Parameters params = Parameters());
+         std::string format,
+         Parameters params = Parameters());
 
 
 json
 validate(const std::vector<std::array<double, 3>>& vertices,
-              const std::vector<std::vector<int>>& triangle_ids,
-              Parameters params = Parameters());
+         const std::vector<std::vector<int>>& triangle_ids,
+         Parameters params = Parameters());
 
 
 bool
 is_valid(const std::vector<std::array<double, 3>>& vertices,
-              const std::vector<std::vector<int>>& triangle_ids,
-              Parameters params = Parameters());
+         const std::vector<std::vector<int>>& triangle_ids,
+         Parameters params = Parameters());
 
 }
 

--- a/src/val3dity.h
+++ b/src/val3dity.h
@@ -28,26 +28,11 @@
 #ifndef val3dity_h
 #define val3dity_h
 
-#include <iostream>
 #include "nlohmann-json/json.hpp"
 
 using json = nlohmann::json;
 
 namespace val3dity {
-
-//todo move these somewhere else
-class NullBuffer : public std::streambuf {
-protected:
-    virtual int_type overflow(int_type c);
-};
-
-extern NullBuffer nullBuffer;
-extern std::ostream nullStream;
-extern std::ostream* val3ditycout;
-extern std::ostream* val3dityclog;
-
-void output_terminal(bool output_terminal);
-
 
 struct Parameters {
     double _tol_snap = 0.001;
@@ -59,22 +44,18 @@ struct Parameters {
     Parameters& tol_snap(double tol_snap) { _tol_snap = tol_snap;
         return *this;
     }
-
     Parameters& planarity_d2p_tol(double planarity_d2p_tol) {
         _planarity_d2p_tol = planarity_d2p_tol;
         return *this;
     }
-
     Parameters& planarity_n_tol(double planarity_n_tol) {
         _planarity_n_tol = planarity_n_tol;
         return *this;
     }
-
     Parameters& overlap_tol(double overlap_tol) {
         _overlap_tol = overlap_tol;
         return *this;
     }
-
     Parameters& terminal_output(bool terminal_output) {
         _terminal_output = terminal_output;
         return *this;

--- a/src/val3dity.h
+++ b/src/val3dity.h
@@ -26,6 +26,7 @@
   Julianalaan 134, Delft 2628BL, the Netherlands
 */
 
+#include <iostream>
 
 #include "nlohmann-json/json.hpp"
 
@@ -33,14 +34,73 @@ using json = nlohmann::json;
 
 namespace val3dity {
 
+//todo move all this to a separate file
+
+class Val3dityBuffer : public std::streambuf
+{
+protected:
+    virtual int_type overflow(int_type c) = 0;
+};
+
+class CoutRedirectBuffer : public Val3dityBuffer
+{
+protected:
+  // Override the overflow method to handle character output
+  virtual int_type overflow(int_type c) override {
+    if (c != traits_type::eof()) {
+      // Write the character to std::cout
+      std::cout.put(char(c));
+    }
+    return c;
+  }
+};
+
+class ClogRedirectBuffer : public Val3dityBuffer
+{
+protected:
+    // Override the overflow method to handle character output
+    virtual int_type overflow(int_type c) override {
+        if (c != traits_type::eof()) {
+            // Write the character to std::clog
+            std::clog.put(char(c));
+        }
+        return c;
+    }
+};
+
+
+class NullBuffer : public Val3dityBuffer {
+protected:
+    // Override the overflow method to discard the output
+    virtual int_type overflow(int_type c) override {
+        // Return something other than EOF to signify success
+        return traits_type::not_eof(c);
+    }
+};
+
+std::unique_ptr<Val3dityBuffer> set_cout(bool terminal_output = true)
+{
+  if (terminal_output)
+    return std::make_unique<CoutRedirectBuffer>();
+  else
+    return std::make_unique<NullBuffer>();
+};
+std::unique_ptr<Val3dityBuffer> set_clog(bool terminal_output = true)
+{
+  if (terminal_output)
+    return std::make_unique<ClogRedirectBuffer>();
+  else
+    return std::make_unique<NullBuffer>();
+};
+
 struct Parameters {
     double _tol_snap = 0.001;
     double _planarity_d2p_tol = 0.01;
     double _planarity_n_tol = 20.0;
     double _overlap_tol = -1.0;
+    bool _terminal_output = true;
 
-    Parameters& tol_snap(double tol_snap) {
-        _tol_snap = tol_snap;
+    Parameters& tol_snap(double tol_snap) { _tol_snap = tol_snap;
         return *this;
     }
 
@@ -58,35 +118,40 @@ struct Parameters {
         _overlap_tol = overlap_tol;
         return *this;
     }
+
+    Parameters& terminal_output(bool terminal_output) {
+        _terminal_output = terminal_output;
+        return *this;
+    }
 };
 
 
 bool
-is_valid(json& j, Parameters param = Parameters());
+is_valid(json& j, Parameters params = Parameters());
 
 json
-validate(json& j, Parameters param = Parameters());
+validate(json& j, Parameters params = Parameters());
 
 bool
 is_valid(std::string& input,
               std::string format,
-              Parameters param = Parameters());
+              Parameters params = Parameters());
 
 json
 validate(std::string& input,
               std::string format,
-              Parameters param = Parameters());
+              Parameters params = Parameters());
 
 
 json
 validate(const std::vector<std::array<double, 3>>& vertices,
               const std::vector<std::vector<int>>& triangle_ids,
-              Parameters param = Parameters());
+              Parameters params = Parameters());
 
 
 bool
 is_valid(const std::vector<std::array<double, 3>>& vertices,
               const std::vector<std::vector<int>>& triangle_ids,
-              Parameters param = Parameters());
+              Parameters params = Parameters());
 
 }

--- a/src/val3dity_ostream.cpp
+++ b/src/val3dity_ostream.cpp
@@ -1,0 +1,50 @@
+/*
+  val3dity
+
+  Copyright (c) 2011-2022, 3D geoinformation research group, TU Delft
+
+  This file is part of val3dity.
+
+  val3dity is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  val3dity is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with val3dity.  If not, see <http://www.gnu.org/licenses/>.
+
+  For any information or further details about the use of val3dity, contact
+  Hugo Ledoux
+  <h.ledoux@tudelft.nl>
+  Faculty of Architecture & the Built Environment
+  Delft University of Technology
+  Julianalaan 134, Delft 2628BL, the Netherlands
+*/
+
+#include "val3dity_ostream.h"
+
+namespace val3dity
+{
+
+std::streambuf::int_type NullBuffer::overflow(int_type c)
+{
+  return traits_type::not_eof(c);
+}
+
+static NullBuffer nullBuffer;
+static std::ostream nullStream(&nullBuffer);
+std::ostream* val3ditycout = &std::cout;
+std::ostream* val3dityclog = &std::clog;
+
+void output_terminal(bool output_terminal)
+{
+  val3ditycout = output_terminal ? &std::cout : &nullStream;
+  val3dityclog = output_terminal ? &std::clog : &nullStream;
+}
+
+} // namespace val3dity

--- a/src/val3dity_ostream.cpp
+++ b/src/val3dity_ostream.cpp
@@ -41,10 +41,10 @@ static std::ostream nullStream(&nullBuffer);
 std::ostream* val3ditycout = &std::cout;
 std::ostream* val3dityclog = &std::clog;
 
-void output_terminal(bool output_terminal)
+void terminal_output(bool terminal_output)
 {
-  val3ditycout = output_terminal ? &std::cout : &nullStream;
-  val3dityclog = output_terminal ? &std::clog : &nullStream;
+  val3ditycout = terminal_output ? &std::cout : &nullStream;
+  val3dityclog = terminal_output ? &std::clog : &nullStream;
 }
 
 } // namespace val3dity

--- a/src/val3dity_ostream.h
+++ b/src/val3dity_ostream.h
@@ -1,0 +1,50 @@
+/*
+  val3dity
+
+  Copyright (c) 2011-2022, 3D geoinformation research group, TU Delft
+
+  This file is part of val3dity.
+
+  val3dity is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  val3dity is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with val3dity.  If not, see <http://www.gnu.org/licenses/>.
+
+  For any information or further details about the use of val3dity, contact
+  Hugo Ledoux
+  <h.ledoux@tudelft.nl>
+  Faculty of Architecture & the Built Environment
+  Delft University of Technology
+  Julianalaan 134, Delft 2628BL, the Netherlands
+*/
+
+#include <iostream>
+
+#ifndef val3dity_ostream_h
+#define val3dity_ostream_h
+
+namespace val3dity
+{
+
+class NullBuffer : public std::streambuf
+{
+protected:
+  virtual int_type overflow(int_type c) override;
+};
+
+extern std::ostream* val3ditycout;
+extern std::ostream* val3dityclog;
+
+void output_terminal(bool terminal_output);
+
+} // namespace val3dity
+
+#endif /* val3dity_ostream_h */

--- a/src/val3dity_ostream.h
+++ b/src/val3dity_ostream.h
@@ -43,7 +43,7 @@ protected:
 extern std::ostream* val3ditycout;
 extern std::ostream* val3dityclog;
 
-void output_terminal(bool terminal_output);
+void terminal_output(bool terminal_output);
 
 } // namespace val3dity
 

--- a/src/val3dity_ostream.h
+++ b/src/val3dity_ostream.h
@@ -26,10 +26,10 @@
   Julianalaan 134, Delft 2628BL, the Netherlands
 */
 
-#include <iostream>
-
 #ifndef val3dity_ostream_h
 #define val3dity_ostream_h
+
+#include <iostream>
 
 namespace val3dity
 {

--- a/src/validate_prim_toporel.cpp
+++ b/src/validate_prim_toporel.cpp
@@ -32,7 +32,7 @@
 #include "input.h"
 #include "Solid.h"
 #include "CompositeSolid.h"
-#include <iostream>
+#include "val3dity_ostream.h"
 #include <sstream>
 
 #include <CGAL/box_intersection_d.h>
@@ -65,13 +65,13 @@ struct Report_intersections {
     if (*thecount % 25 == 0) {
       int r = rand() % 3;
       if (r == 0)
-        std::cout << "\b|" << std::flush;
+        *val3ditycout << "\b|" << std::flush;
       else if (r == 1)
-        std::cout << "\b/" << std::flush;
+        *val3ditycout << "\b/" << std::flush;
       else if (r == 2)
-        std::cout << "\b-" << std::flush;
+        *val3ditycout << "\b-" << std::flush;
       else
-        std::cout << "\b\\" << std::flush;
+        *val3ditycout << "\b\\" << std::flush;
     }
     //-- we check here if the 2 (usually eroded) Nefs are intersecting, 
     //-- if yes then an error is added to the list lsErrors
@@ -98,7 +98,7 @@ bool are_cells_interior_disconnected_with_aabb(std::vector<std::tuple<std::strin
                                                std::vector<Error>& lsErrors, 
                                                double tol_overlap)
 {
-  std::clog << "--- Constructing Nef Polyhedra ---" << std::endl;
+  *val3dityclog << "--- Constructing Nef Polyhedra ---" << std::endl;
   std::vector<Nef_polyhedron*>                lsNefs;
   std::vector<std::tuple<std::string,Solid*>> subsetCells;
   for (auto& c : lsCells)
@@ -117,7 +117,7 @@ bool are_cells_interior_disconnected_with_aabb(std::vector<std::tuple<std::strin
       lsNefs.push_back(tmpnef);
     subsetCells.push_back(c);
   }
-  std::clog << "--- Constructing AABB tree ---" << std::endl;
+  *val3dityclog << "--- Constructing AABB tree ---" << std::endl;
   std::vector<AABB> aabbs;
   int counter = 0;
   for ( Iterator i = lsNefs.begin(); i != lsNefs.end(); ++i)
@@ -129,14 +129,14 @@ bool are_cells_interior_disconnected_with_aabb(std::vector<std::tuple<std::strin
   std::vector<std::string> lsCellIDs;
   for (auto each : subsetCells)
     lsCellIDs.push_back(std::get<0>(each));
-  std::clog << "--- Testing intersections between Nefs ---" << std::endl;
+  *val3dityclog << "--- Testing intersections between Nefs ---" << std::endl;
   int n = lsErrors.size();
   int count = 0; 
   if (lsNefs.size() > 500) {
-    std::cout << "Testing intersections between " << lsNefs.size() << " cells, this could be slow." << std::endl << std::flush;
+    *val3ditycout << "Testing intersections between " << lsNefs.size() << " cells, this could be slow." << std::endl << std::flush;
   }
   CGAL::box_self_intersection_d( aabbs.begin(), aabbs.end(), Report_intersections(lsNefs, lsCellIDs, lsErrors, errorcode_to_assign, count));
-  std::clog << "Total AABB tests: " << count << std::endl;
+  *val3dityclog << "Total AABB tests: " << count << std::endl;
   if (lsErrors.size() > n)
     return false;
   else


### PR DESCRIPTION
My attempt on tackling the issue with the leaky ostream.

Example how I control it in the API:

```
bool isvalid = val3dity::is_valid(points, polys, val3dity::Parameters().terminal_output(false));
```

To do this, I also introduced the named parameter idiom to the API. You can chain the other parameters and the order of calling shouldn't matter.

Naming still needs a bit of work (output_terminal, terminal_output, or something else).