### PR TITLE
CGAL 6.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,9 @@ endif(MSVC)
 
 # CGAL
 find_package( CGAL QUIET COMPONENTS )
-if (NOT CGAL_FOUND )
+if ( CGAL_FOUND )
+  message(STATUS "CGAL found: ${CGAL_DIR}")
+else()
   message(SEND_ERROR "val3dity requires the CGAL library")
   return()  
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required (VERSION 3.16)
 project( val3dity )
 
 
-add_definitions(-std=c++14)
+add_definitions(-std=c++17)
 
 set( CMAKE_BUILD_TYPE "Release")
 set( CMAKE_CXX_FLAGS "-O2" )
@@ -24,12 +24,7 @@ endif(MSVC)
 
 # CGAL
 find_package( CGAL QUIET COMPONENTS )
-if ( CGAL_FOUND )
-  include( ${CGAL_USE_FILE} )
-  message(STATUS "CGAL found")
-  message(STATUS ${CGAL_LIBRARIES})
-  message(STATUS ${CGAL_3RD_PARTY_LIBRARIES})
-else()
+if (NOT CGAL_FOUND )
   message(SEND_ERROR "val3dity requires the CGAL library")
   return()  
 endif()


### PR DESCRIPTION
It seems val3dity only needs a minor update to work with CGAL 6.0 and it's backwards compatible.