### PR TITLE
Fix compilation issues with eigen 5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # Eigen
-find_package(Eigen3 3.1.0 QUIET)
+find_package(Eigen3 REQUIRED)
 include(CGAL_Eigen3_support)
 
 


### PR DESCRIPTION
Eigen recently published eigen5 and the current CMakeLists ends up in an error:

```
CMake Error at CMakeLists.txt:81 (target_link_libraries):
  Target "val3dity" links to:

    CGAL::Eigen3_support

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.
```
    
This small change should fix it